### PR TITLE
Resolved a few issues on VCA Household Visitation as follows

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/ec_client_fields.json
+++ b/opensrp-ecap-chw/src/ecap/assets/ec_client_fields.json
@@ -1181,6 +1181,13 @@
           }
         },
         {
+          "column_name": "landmark",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.landmark"
+          }
+        },
+        {
           "column_name": "caregiver_phone",
           "type": "Client",
           "json_mapping": {
@@ -1271,6 +1278,23 @@
             "field": "attributes.reason_for_hiv_risk"
           }
         },
+        {
+          "column_name": "is_biological_child_of_mother_living_with_hiv",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.is_biological_child_of_mother_living_with_hiv"
+          }
+        },
+        {
+          "column_name": "is_mother_currently_on_treatment_wlhiv",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.is_mother_currently_on_treatment_wlhiv"
+          }
+        },
+
+
+
         {
           "column_name": "secure",
           "type": "Client",

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_vca_0_20_years.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_vca_0_20_years.json
@@ -124,7 +124,7 @@
         "options": [
           {
             "key": "yes",
-            "text": "HIV Negative"
+            "text": "HIV Positive"
           },
           {
             "key": "no",
@@ -307,7 +307,7 @@
         "type": "edit_text",
         "hint": "Number of MMD months of drugs ",
         "edit_type": "number",
-        "read_only": "true",
+        "read_only": "false",
         "v_required": {
           "value": false,
           "err": "Indicate the number of MMD months of drugs "
@@ -478,6 +478,33 @@
           }
         }
       },
+
+      {
+        "key": "visits",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "visits",
+        "type": "native_radio",
+        "label": "Is this the first visit?",
+        "options": [
+          {
+            "key": "yes",
+            "text": "Yes",
+            "value": false
+          },
+          {
+            "key": "no",
+            "text": "No",
+            "value": false
+          }
+        ],
+        "relevance": {
+          "step1:date_hiv": {
+            "type": "string",
+            "ex": "greaterThan(., \"3\")"
+          }
+        }
+      },
       {
         "key": "visit_hiv_test",
         "openmrs_entity_parent": "",
@@ -498,14 +525,12 @@
           }
         ],
         "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "household_visitation_for_vca_0_20_years.yml"
-            }
+          "step1:visits": {
+            "type": "string",
+            "ex": "equalTo(., \"yes\")"
           }
         }
       },
-
       {
         "key": "referred_for_testing",
         "openmrs_entity_parent": "",
@@ -555,19 +580,18 @@
             "value": false
           },
           {
-            "key": "none",
-            "text": "None",
+            "key": "n/a",
+            "text": "N/A",
             "value": false
           }
         ],
         "relevance": {
-          "step1:is_hiv_positive": {
+          "step1:visits": {
             "type": "string",
             "ex": "equalTo(., \"no\")"
           }
         }
       },
-
       {
         "key": "hiv_muac",
         "openmrs_entity_parent": "",
@@ -1922,10 +1946,9 @@
           }
         ],
         "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "household_visitation_form_0_20.yml"
-            }
+          "step1:age": {
+            "type": "string",
+            "ex": "greaterThan(., \"5\")"
           }
         }
       },

--- a/opensrp-ecap-chw/src/ecap/assets/rule/household_visitation_form_0_20.yml
+++ b/opensrp-ecap-chw/src/ecap/assets/rule/household_visitation_form_0_20.yml
@@ -241,7 +241,7 @@ actions:
 name: step1_currently_in_school
 description: currently_in_school
 priority: 1
-condition: "step1_age >= 3"
+condition: "step1_age >  5"
 actions:
   - "isRelevant = true"
 ---

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/IndexPersonDao.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/IndexPersonDao.java
@@ -174,7 +174,7 @@ public class IndexPersonDao  extends AbstractDao {
         String sql = "SELECT *, first_name AS adolescent_first_name,last_name As adolescent_last_name, gender as adolescent_gender FROM ec_client_index WHERE unique_id = '" + baseEntityID + "' ";
         DataMap<Child> dataMap = c -> {
             return new Child(
-
+                    getCursorValue(c, "landmark"),
                     getCursorValue(c, "client_screened"),
                     getCursorValue(c, "client_result"),
                     getCursorValue(c, "tpt_client_eligibility"),

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/Child.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/Child.java
@@ -8,12 +8,13 @@ import java.io.Serializable;
 public class Child implements Serializable {
 
     public static final String ENTITY_ID = "entity_id";
-    
+
     public Child() {
 
     }
 
-    public Child(String client_screened,String client_result,String tpt_client_eligibility, String tpt_client_initiated, String case_status, String reason, String other_reason, String base_entity_id, String household_id, String unique_id, String first_name, String last_name, String adolescent_gender, String adolescent_birthdate, String subpop1, String subpop2, String subpop3, String subpop4, String subpop5, String subpop6, String is_biological_child_of_mother_living_with_hiv, String date_referred, String date_enrolled, String art_check_box, String art_number, String date_started_art, String date_last_vl, String date_next_vl, String vl_last_result, String vl_suppressed, String child_mmd, String level_mmd, String caregiver_name, String caregiver_birth_date, String caregiver_sex, String caregiver_hiv_status, String relation, String caregiver_phone, String health_facility, String gender,  String relational_id, String index_check_box, String date_removed, String acceptance, String date_screened, String date_hiv_known, String is_hiv_positive, String is_on_hiv_treatment, String adolescent_first_name, String adolescent_last_name, String province, String district, String ward, String adolescent_village, String partner, String is_viral_load_test_results_on_file, String is_tb_screening_results_on_file, String screened_for_malnutrition, String gets_tb_preventive_therapy, String takes_drugs_to_prevent_other_diseases, String less_3, String positive_mother, String is_mother_currently_on_treatment, String mother_art_number, String is_mother_adhering_to_treatment, String is_mother_virally_suppressed, String is_child_hiv_positive, String child_receiving_breastfeeding, String child_tested_for_hiv_inline_with_guidelines, String receives_drugs_to_prevent_hiv_and_other_illnesses, String child_been_screened_for_malnutrition, String child_gets_drugs_to_prevent_tb_hei, String child_enrolled_in_early_childhood_development_program, String school, String other_school, String caregiver_nrc, String vl_next_result, String physical_address,String date_offered_enrollment) {
+    public Child(String landmark, String client_screened,String client_result,String tpt_client_eligibility, String tpt_client_initiated, String case_status, String reason, String other_reason, String base_entity_id, String household_id, String unique_id, String first_name, String last_name, String adolescent_gender, String adolescent_birthdate, String subpop1, String subpop2, String subpop3, String subpop4, String subpop5, String subpop6, String is_biological_child_of_mother_living_with_hiv, String date_referred, String date_enrolled, String art_check_box, String art_number, String date_started_art, String date_last_vl, String date_next_vl, String vl_last_result, String vl_suppressed, String child_mmd, String level_mmd, String caregiver_name, String caregiver_birth_date, String caregiver_sex, String caregiver_hiv_status, String relation, String caregiver_phone, String health_facility, String gender,  String relational_id, String index_check_box, String date_removed, String acceptance, String date_screened, String date_hiv_known, String is_hiv_positive, String is_on_hiv_treatment, String adolescent_first_name, String adolescent_last_name, String province, String district, String ward, String adolescent_village, String partner, String is_viral_load_test_results_on_file, String is_tb_screening_results_on_file, String screened_for_malnutrition, String gets_tb_preventive_therapy, String takes_drugs_to_prevent_other_diseases, String less_3, String positive_mother, String is_mother_currently_on_treatment, String mother_art_number, String is_mother_adhering_to_treatment, String is_mother_virally_suppressed, String is_child_hiv_positive, String child_receiving_breastfeeding, String child_tested_for_hiv_inline_with_guidelines, String receives_drugs_to_prevent_hiv_and_other_illnesses, String child_been_screened_for_malnutrition, String child_gets_drugs_to_prevent_tb_hei, String child_enrolled_in_early_childhood_development_program, String school, String other_school, String caregiver_nrc, String vl_next_result, String physical_address,String date_offered_enrollment) {
+        this.landmark = landmark;
         this.client_screened = client_screened;
         this.client_result = client_result;
         this.tpt_client_eligibility = tpt_client_eligibility;
@@ -94,6 +95,9 @@ public class Child implements Serializable {
         this.physical_address = physical_address;
         this.date_offered_enrollment =date_offered_enrollment;
     }
+    @SerializedName("landmark")
+    @Expose
+    private String landmark;
 
     @SerializedName("client_screened")
     @Expose


### PR DESCRIPTION

-On HIV risk assessment on the section for HIV status remove the option "HIV status not required based on HIV risk assessment" because we are in that form. This option should only appear in other forms #534 (In Progress)
-Household visitation for VCAs 0-20 years - Implement the following skip logic on health section for an HIV negative VCA #532
-Ensure the field "Number of months" is clickable on household visitation #531
