### PR TITLE
Resolved the following issues

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening_entry.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening_entry.json
@@ -394,7 +394,7 @@
       {
         "key": "primary_caregivers_only",
         "type": "label",
-        "text": "          For Primary Caregivers Only",
+        "text": "For Primary Caregivers Only",
         "label_text_style": "bold"
       },
       {

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_vca_0_20_years.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_vca_0_20_years.json
@@ -120,7 +120,7 @@
         "openmrs_entity_id": "is_hiv_positive",
         "type": "native_radio",
         "label": "HIV Status",
-        "read_only": false,
+        "read_only": true,
         "options": [
           {
             "key": "yes",
@@ -1701,6 +1701,8 @@
           }
         }
       },
+
+
       {
         "key": "child_ever_experienced_sexual_violence",
         "openmrs_entity_parent": "",
@@ -1748,12 +1750,35 @@
           }
         ],
         "relevance": {
-          "step1:sexually_abused": {
+          "step1:child_ever_experienced_sexual_violence": {
             "type": "string",
             "ex": "equalTo(., \"yes\")"
           }
         }
       },
+      {
+        "key": "type_of_neglect_sexual",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "type_of_neglect_sexual",
+        "type": "edit_text",
+        "hint": "list the signs observed or type of violence reported",
+        "edit_type": "name",
+        "read_only": "false",
+        "look_up": "true",
+        "v_regex": {
+          "value": "[A-Za-z\\s\\.\\-]*",
+          "err": "Please enter a valid name"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "household_visitation_form_0_20.yml"
+            }
+          }
+        }
+      },
+
       {
         "key": "parenting_intervention",
         "openmrs_entity_parent": "",
@@ -1774,32 +1799,26 @@
           }
         ],
         "relevance": {
-          "step1:sexually_abused": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
-        }
-      },
-
-      {
-        "key": "type_of_neglect_sexual",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "type_of_neglect_sexual",
-        "type": "edit_text",
-        "hint": "list the signs observed or type of violence reported",
-        "edit_type": "name",
-        "read_only": "false",
-        "look_up": "true",
-        "v_regex": {
-          "value": "[A-Za-z\\s\\.\\-]*",
-          "err": "Please enter a valid name"
-        },
-        "relevance": {
           "rules-engine": {
             "ex-rules": {
               "rules-file": "household_visitation_form_0_20.yml"
             }
+          }
+        }
+      },
+      {
+        "key": "toasterr",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "toaster_notes",
+        "text": " Project-filed report of suspected abuse to child protection office, police or other local authority",
+        "toaster_type": "info",
+        "toaster_info_text": "",
+        "relevance": {
+          "step1:hiv_test": {
+            "type": "string",
+            "ex": "equalTo(., \"No\")"
           }
         }
       },
@@ -1896,7 +1915,7 @@
         "openmrs_entity_id": "referred_services",
         "type": "edit_text",
         "read_only": "false",
-        "hint": "List the services",
+        "hint": "List the other referred services",
         "relevance": {
           "step1:child_other_services": {
             "type": "string",
@@ -1947,35 +1966,10 @@
           }
         ],
         "relevance": {
-          "step1:age": {
-            "type": "string",
-            "ex": "greaterThan(., \"5\")"
-          }
-        }
-      },
-      {
-        "key": "not_in_school",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "not_in_school",
-        "type": "native_radio",
-        "label": "If child is of school going age is not in school, were the barriers \nto being in school discussed?",
-        "options": [
-          {
-            "key": "yes",
-            "text": "Yes",
-            "value": false
-          },
-          {
-            "key": "no",
-            "text": "No",
-            "value": false
-          }
-        ],
-        "relevance": {
-          "step1:currently_in_school": {
-            "type": "string",
-            "ex": "equalTo(., \"no\")"
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "household_visitation_form_0_20.yml"
+            }
           }
         }
       },
@@ -1990,12 +1984,48 @@
         "read_only": "false",
         "look_up": "true",
         "relevance": {
-          "step1:not_in_school": {
+          "step1:currently_in_school": {
             "type": "string",
             "ex": "equalTo(., \"yes\")"
           }
         }
       },
+      {
+        "key": "ovc_caregiver",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "ovc_caregiver",
+        "type": "edit_text",
+        "hint": "Days missed as reported by OVC/Caregiver",
+        "edit_type": "number",
+        "read_only": "true",
+        "look_up": "true",
+        "relevance": {
+          "step1:currently_in_school": {
+            "type": "string",
+            "ex": "equalTo(., \"yes\")"
+          }
+        }
+      },
+
+      {
+        "key": "verified_by_school_days",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "verified_by_school_days",
+        "type": "edit_text",
+        "hint": "Days missed verified by the school",
+        "edit_type": "number",
+        "read_only": "false",
+        "look_up": "true",
+        "relevance": {
+          "step1:currently_in_school": {
+            "type": "string",
+            "ex": "equalTo(., \"yes\")"
+          }
+        }
+      },
+
       {
         "key": "challenges_barriers",
         "openmrs_entity_parent": "",
@@ -2023,6 +2053,34 @@
           }
         }
       },
+
+      {
+        "key": "not_in_school",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "not_in_school",
+        "type": "native_radio",
+        "label": "If child is of school going age is not in school, were the barriers \nto being in school discussed?",
+        "options": [
+          {
+            "key": "yes",
+            "text": "Yes",
+            "value": false
+          },
+          {
+            "key": "no",
+            "text": "No",
+            "value": false
+          }
+        ],
+        "relevance": {
+          "step1:currently_in_school": {
+            "type": "string",
+            "ex": "equalTo(., \"no\")"
+          }
+        }
+      },
+
       {
         "key": "child_household",
         "openmrs_entity_parent": "",
@@ -2072,42 +2130,6 @@
       },
 
       {
-        "key": "ovc_caregiver",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "ovc_caregiver",
-        "type": "edit_text",
-        "hint": "Days missed as reported by OVC/Caregiver",
-        "edit_type": "number",
-        "read_only": "true",
-        "look_up": "true",
-        "relevance": {
-          "step1:not_in_school": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
-        }
-      },
-
-      {
-        "key": "verified_by_school_days",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "verified_by_school_days",
-        "type": "edit_text",
-        "hint": "Days missed verified by the school",
-        "edit_type": "number",
-        "read_only": "false",
-        "look_up": "true",
-        "relevance": {
-          "step1:age": {
-            "type": "string",
-            "ex": "greaterThan(., \"5\")"
-          }
-        }
-      },
-
-      {
         "key": "label",
         "openmrs_entity_parent": "",
         "openmrs_entity": "",
@@ -2126,9 +2148,10 @@
         "read_only": "false",
         "look_up": "true",
         "relevance": {
-          "step1:age": {
-            "type": "string",
-            "ex": "greaterThan(., \"5\")"
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "household_visitation_form_0_20.yml"
+            }
           }
         }
       },
@@ -2143,9 +2166,10 @@
         "read_only": "false",
         "look_up": "false",
         "relevance": {
-          "step1:age": {
-            "type": "string",
-            "ex": "greaterThan(., \"5\")"
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "household_visitation_form_0_20.yml"
+            }
           }
         }
       },
@@ -2342,9 +2366,10 @@
           "err": "Please enter a valid name"
         },
         "relevance": {
-          "step1:age": {
-            "type": "string",
-            "ex": "greaterThan(., \"5\")"
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "household_visitation_form_0_20.yml"
+            }
           }
         }
       },
@@ -2365,9 +2390,10 @@
           "err": "Number must begin with 077,076,095, 096, or 097 and must be a total of 10 digits in length"
         },
         "relevance": {
-          "step1:age": {
-            "type": "string",
-            "ex": "greaterThan(., \"5\")"
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "household_visitation_form_0_20.yml"
+            }
           }
         }
       },
@@ -2389,9 +2415,10 @@
           "err": "Date Signed"
         },
         "relevance": {
-          "step1:age": {
-            "type": "string",
-            "ex": "greaterThan(., \"5\")"
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "household_visitation_form_0_20.yml"
+            }
           }
         }
       },

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/vca_assessment.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/vca_assessment.json
@@ -92,11 +92,11 @@
         "options": [
           {
             "key": "yes",
-            "text": "Yes"
+            "text": "Positive"
           },
           {
             "key": "no",
-            "text": "No"
+            "text": "Negative"
           },
           {
             "key": "unknown",
@@ -319,7 +319,7 @@
         "type": "edit_text",
         "hint": "VL Result",
         "edit_type": "number",
-        "read_only": true,
+        "read_only": false,
         "relevance": {
           "step1:viral_load": {
             "type": "string",

--- a/opensrp-ecap-chw/src/ecap/assets/rule/household_visitation_form_0_20.yml
+++ b/opensrp-ecap-chw/src/ecap/assets/rule/household_visitation_form_0_20.yml
@@ -234,7 +234,7 @@ actions:
 name: step1_progression_child_household
 description: progression_child_household
 priority: 1
-condition: "(step1_current_calendar == 1 && step1_verified_by_school == 1 || step1_current_calendar == 2 && step1_verified_by_school == 2 || step1_current_calendar == 3 && step1_verified_by_school == 3 || step1_current_calendar == 4 && step1_verified_by_school == 4 || step1_current_calendar == 5 && step1_verified_by_school == 5 || step1_current_calendar == 6 && step1_verified_by_school == 6 || step1_current_calendar == 7 && step1_verified_by_school == 7 || step1_current_calendar == 8 && step1_verified_by_school == 8 || step1_current_calendar == 9 && step1_verified_by_school == 9 || step1_current_calendar == 10 && step1_verified_by_school == 10 || step1_current_calendar == 11 && step1_verified_by_school == 11 || step1_current_calendar == 12 && step1_verified_by_school == 12) "
+condition: "step1_did_not_progress.contains('yes') || step1_did_not_progress.contains('no')"
 actions:
   - "isRelevant = true"
 ---
@@ -252,9 +252,58 @@ condition: "step1_age >  5"
 actions:
   - "isRelevant = true"
 ---
-name: step1_currently_in_school
-description: currently_in_school
+name: step1_parenting_intervention
+description: parenting_intervention
 priority: 1
-condition: "step1_age >= 3"
+condition: "step1_vsu_legal_support.contains('yes') || step1_vsu_legal_support.contains('no') "
+actions:
+  - "isRelevant = true"
+---
+name: step1_toasterr
+description: toasterr
+priority: 1
+condition: "step1_parenting_intervention.contains('yes') || step1_parenting_intervention.contains('no') "
+actions:
+  - "isRelevant = true"
+---
+name: step1_child_household
+description: child_household
+priority: 1
+condition: "step1_challenges_barriers.contains('yes') || step1_challenges_barriers.contains('no') "
+actions:
+  - "isRelevant = true"
+---
+name: step1_verified_by_school
+description: verified_by_school
+priority: 1
+condition: "step1_age >  5 && step1_age <= 19"
+actions:
+  - "isRelevant = true"
+---
+name: step1_current_calendar
+description: current_calendar
+priority: 1
+condition: "step1_age >  5 && step1_age <= 19"
+actions:
+  - "isRelevant = true"
+---
+name: step1_school_administration_name
+description: school_administration_name
+priority: 1
+condition: "step1_age >  5 && step1_age <= 19"
+actions:
+  - "isRelevant = true"
+---
+name: step1_telephone_number
+description: telephone_number
+priority: 1
+condition: "step1_age >  5 && step1_age <= 19"
+actions:
+  - "isRelevant = true"
+---
+name: step1_school_administration_date_signed
+description: school_administration_date_signed
+priority: 1
+condition: "step1_age >  5 && step1_age <= 19"
 actions:
   - "isRelevant = true"

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/IndexDetailsActivity.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/IndexDetailsActivity.java
@@ -954,17 +954,18 @@ public class IndexDetailsActivity extends AppCompatActivity {
 
                 case "household_visitation_for_vca_0_20_years":
 
-               // if(vcaVisitationModel == null){
+                if(vcaVisitationModel == null){
 
                     //Pulls data for populating from indexchild when adding data for the very first time
                     CoreJsonFormUtils.populateJsonForm(formToBeOpened, oMapper.convertValue(indexChild, Map.class));
                     formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(1).put("value", vcaAge);
 
-              /*  } else {
+                } else {
 
                     formToBeOpened.put("entity_id", this.vcaVisitationModel.getBase_entity_id());
                     CoreJsonFormUtils.populateJsonForm(formToBeOpened, oMapper.convertValue(vcaVisitationModel, Map.class));
-                }*/
+                    formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(1).put("value", vcaAge);
+                }
                 break;
 
             case "referral":

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/VcaVisitationDao.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/VcaVisitationDao.java
@@ -56,7 +56,7 @@ public class VcaVisitationDao extends AbstractDao {
             record.setBase_entity_id(getCursorValue(c, "base_entity_id"));
             record.setAge(getCursorValue(c, "age"));
             record.setVisit_date(getCursorValue(c, "visit_date"));
-            record.setHiv_status(getCursorValue(c, "is_hiv_positive"));
+            record.setIs_hiv_positive(getCursorValue(c, "is_hiv_positive"));
             record.setChild_art(getCursorValue(c, "child_art"));
             record.setClinical_care(getCursorValue(c, "clinical_care"));
             record.setArt_appointment(getCursorValue(c, "art_appointment"));

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/VcaVisitationModel.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/VcaVisitationModel.java
@@ -5,6 +5,7 @@ public class VcaVisitationModel {
     private String base_entity_id;
     private String age;
     private String visit_date;
+    private String is_hiv_positive;
     private String hiv_status;
     private String child_art;
     private String clinical_care;
@@ -108,6 +109,22 @@ public class VcaVisitationModel {
 
     public void setAge(String age) {
         this.age = age;
+    }
+
+    public String getVisit_date() {
+        return visit_date;
+    }
+
+    public void setVisit_date(String visit_date) {
+        this.visit_date = visit_date;
+    }
+
+    public String getIs_hiv_positive() {
+        return is_hiv_positive;
+    }
+
+    public void setIs_hiv_positive(String is_hiv_positive) {
+        this.is_hiv_positive = is_hiv_positive;
     }
 
     public String getHiv_status() {
@@ -812,13 +829,5 @@ public class VcaVisitationModel {
 
     public void setSchool_administration_signature(String school_administration_signature) {
         this.school_administration_signature = school_administration_signature;
-    }
-
-    public String getVisit_date() {
-        return visit_date;
-    }
-
-    public void setVisit_date(String visit_date) {
-        this.visit_date = visit_date;
     }
 }


### PR DESCRIPTION
-Household visitation on Schooled (School Attendance) - Implement the following skip logic #553
-The fields below the section schooled on household visitation are not visible #552
-On vulnerability assessment if "Yes" the VCA has had a viral load test done in the past 12 months. Make the VL result field clickable. #550
-Change the options on HIV status to "Negative, Positive and Unknown" on Vulnerability Assessment. #548
-Align the label "For Primary Caregivers only" to the left. #547
-Household visitation on safe (Sexual and/or Gender Based Violence) - Implement the following skip logic #545
