### PR TITLE
Resolved the following high priority issues

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening_entry.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening_entry.json
@@ -96,7 +96,7 @@
         "edit_type": "name",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Household ID has been missed"
         }
       },
       {
@@ -110,7 +110,7 @@
         "read_only": "true",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "VCA ID has been missed"
         }
       },
       {
@@ -119,7 +119,7 @@
         "openmrs_entity": "person",
         "openmrs_entity_id": "first_name",
         "type": "edit_text",
-        "hint": "VCA First Name",
+        "hint": "VCA first name",
         "edit_type": "name",
         "v_regex": {
           "value": "[A-Za-z]*",
@@ -127,7 +127,7 @@
         },
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "VCA first name has been missed"
         }
       },
       {
@@ -136,7 +136,7 @@
         "openmrs_entity": "person",
         "openmrs_entity_id": "last_name",
         "type": "edit_text",
-        "hint": "VCA Last Name",
+        "hint": "VCA last name",
         "edit_type": "name",
         "value": "",
         "v_regex": {
@@ -145,7 +145,7 @@
         },
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "VCA last name has been missed"
         }
       },
       {
@@ -154,7 +154,7 @@
         "openmrs_entity": "person_attribute",
         "openmrs_entity_id": "adolescent_birthdate",
         "type": "date_picker",
-        "hint": "VCA Date of birth",
+        "hint": "VCA date of birth",
         "look_up": "true",
         "expanded": false,
         "duration": {
@@ -164,7 +164,7 @@
         "max_date": "today",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "VCA date of birth has been missed"
         }
       },
       {
@@ -186,7 +186,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "VCA gender has been missed"
         }
       },
       {
@@ -228,7 +228,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Sup population has been missed"
         }
       },
       {
@@ -244,7 +244,7 @@
         "look_up": "true",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Health facility has been missed"
         }
       },
       {
@@ -260,7 +260,7 @@
         "look_up": "true",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Province has been missed"
         }
       },
       {
@@ -276,7 +276,7 @@
         "look_up": "true",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "District has been missed"
         }
       },
       {
@@ -292,7 +292,7 @@
         "look_up": "true",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Ward has been missed"
         }
       },
       {
@@ -308,7 +308,7 @@
         "look_up": "true",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Partner has been missed"
         }
       },
       {
@@ -347,7 +347,7 @@
         "hint": "Address",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Village has been missed"
         }
       },
       {
@@ -363,7 +363,7 @@
         "max_date": "today",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Date of screening has been missed"
         }
       },
       {
@@ -376,7 +376,7 @@
         "edit_type": "name",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Screening location has been missed"
         }
       },
       {
@@ -408,7 +408,7 @@
         },
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Caregiver's full name has been missed"
         }
       },
       {
@@ -420,17 +420,17 @@
         "label": "Caregiver's Gender",
         "options": [
           {
-            "key": "male",
+            "key": "Male",
             "text": "Male"
           },
           {
-            "key": "female",
+            "key": "Female",
             "text": "Female"
           }
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Caregiver's gender has been missed"
         }
       },
       {
@@ -450,7 +450,7 @@
         "max_date": "today",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Caregiver's date of birth has been missed"
         }
       },
       {
@@ -497,7 +497,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Have you experienced violence in the home in the last six months has been missed"
         }
       },
       {
@@ -519,7 +519,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Have the children experienced violence in the home in the last six months has been missed"
         }
       },
       {
@@ -551,7 +551,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Caregiver's HIV status has been missed"
         }
       },
       {
@@ -614,7 +614,7 @@
         },
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Caregiver`s ART number has been missed"
         }
       },
       {
@@ -640,51 +640,82 @@
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
         "openmrs_entity_id": "viral_load_results",
-        "type": "edit_text",
-        "hint": "Result of most recent viral load test.",
-        "v_numeric": {
-          "value": "true",
-          "err": "Viral load can only contain numbers"
-        },
-        "v_required": {
-          "value": true,
-          "err": "Required"
-        },
-        "v_regex": {
-          "value": "([0-9]{1}||[0-9]{2}||[0-9]{3})|\\s*",
-          "err": "Viral load cannot be 1000 or above"
-        },
+        "type": "spinner",
+        "hint": "Last VL results",
+        "values": [
+          "Less than 1000 copies/ml",
+          "Above 1000 copies/ml"
+        ],
+        "keys": [
+          "Less than 1000 copies/ml",
+          "Above 1000 copies/ml"
+        ],
         "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "hh_screening_relevance.yml"
-            }
+          "step1:active_on_treatment": {
+            "type": "string",
+            "ex": "equalTo(., \"yes\")"
           }
         }
       },
+      {
+        "key": "vl_suppressed",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "vl_suppressed",
+        "type": "native_radio",
+        "label": "Are you virally suppressed as of your most recent viral load test?",
+        "options": [
+          {
+            "key": "Yes",
+            "text": "Yes"
+          },
+          {
+            "key": "No",
+            "text": "No"
+          }
+        ],
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "hh_screening_calculation.yml"
+            }
+          }
+        },
+        "relevance": {
+          "step1:viral_load_results": {
+            "type": "string",
+            "ex": "equalTo(., \"Less than 1000 copies/ml\")"
+          }
+        }
+      },
+
       {
         "key": "date_of_last_viral_load",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
         "openmrs_entity_id": "date_of_last_viral_load",
         "type": "date_picker",
-        "hint": "Date of last viral load test",
-        "label_info_title": "Date of last viral load test",
+        "hint": "Date of last VL test",
         "expanded": false,
-        "min_date": "today-100y",
-        "max_date": "today",
-        "relevance": {
-          "rules-engine": {
-            "ex-rules": {
-              "rules-file": "hh_screening_relevance.yml"
-            }
-          }
+        "duration": {
+          "label": ""
         },
+        "min_date": "today",
+        "max_date": "today + 100y",
         "v_required": {
-          "value": true,
-          "err": "Required"
+          "value": false,
+          "err": "Please enter date of next viral load"
+        },
+        "relevance": {
+          "step1:active_on_treatment": {
+            "type": "string",
+            "ex": "equalTo(., \"yes\")"
+          }
         }
       },
+
+
+
       {
         "key": "biological_children",
         "openmrs_entity_parent": "",
@@ -704,7 +735,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Do you have biological children 0-2 years has been missed"
         },
         "relevance": {
           "rules-engine": {
@@ -733,7 +764,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Are you and your biological children enrolled in the PMTCT program has been missed"
         },
         "relevance": {
           "rules-engine": {
@@ -749,7 +780,7 @@
         "openmrs_entity": "person_attribute",
         "openmrs_entity_id": "at_risk_reasons",
         "type": "native_radio",
-        "label": "Are there any reasons you may be at risk for HIV?)",
+        "label": "Are there any reasons you may be at risk for HIV?",
         "options": [
           {
             "key": "yes",
@@ -762,7 +793,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Are there any reasons you may be at risk for HIV has been missed"
         },
         "relevance": {
           "step1:caregiver_hiv_status": {
@@ -1317,12 +1348,12 @@
         },
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Name of partner/spouse"
         },
         "relevance": {
           "rules-engine": {
             "ex-rules": {
-              "rules-file": "family_register_relevance.yml"
+              "rules-file": "hh_screening_relevance.yml"
             }
           }
         }
@@ -1341,7 +1372,7 @@
         },
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Name of relationship partner has been missed"
         },
         "relevance": {
           "rules-engine": {
@@ -1374,7 +1405,7 @@
         "edit_type": "number",
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "No. of Women currently pregnant in household has been missed"
         }
       },
       {
@@ -1416,7 +1447,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Number of ITNs  in use"
+          "err": "Number of malaria ITNs in use has been missed"
         }
       },
       {
@@ -1446,12 +1477,12 @@
         "openmrs_entity": "person_attribute",
         "openmrs_entity_id": "emergency_name",
         "type": "edit_text",
-        "hint": "Emergency Contact Name ",
+        "hint": "Emergency contact name ",
         "edit_type": "name",
         "look_up": "true",
         "v_required": {
           "value": true,
-          "err": "This field is required"
+          "err": "Emergency contact name has been missed"
         }
       },
       {
@@ -1479,7 +1510,7 @@
         ],
         "v_required": {
           "value": true,
-          "err": "Required"
+          "err": "Relationship to caregiver has been missed"
         }
       },
       {
@@ -1525,7 +1556,7 @@
         "look_up": "true",
         "v_required": {
           "value": true,
-          "err": "This field is required"
+          "err": "Contact Address has been missed"
         }
       },
 

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/vca_screening.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/vca_screening.json
@@ -136,7 +136,7 @@
         "type": "edit_text",
         "hint": "Ward",
         "value": "Choma Central",
-        "read_only": "true",
+        "read_only": "false",
         "edit_type": "name",
         "look_up": "true"
       },
@@ -229,14 +229,14 @@
         "toaster_type": "info"
       },
       {
-        "key": "adolescent_village",
+        "key": "village",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "adolescent_village",
+        "openmrs_entity_id": "village",
         "type": "edit_text",
         "hint": "Address",
         "v_required": {
-          "value": false,
+          "value": true,
           "err": "Required"
         }
       },
@@ -2248,10 +2248,6 @@
         "min_date": "today-100y",
         "max_date": "today",
         "v_required": {
-          "value": false,
-          "err": "Please enter date you were enrolled"
-        },
-        "v_required": {
           "value": true,
           "err": "Required"
         },
@@ -2312,6 +2308,13 @@
         "v_required": {
           "value": false,
           "err": "You're required check the ART number check box"
+        },
+        "calculation": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "vca_screening_calculation.yml"
+            }
+          }
         },
         "relevance": {
           "rules-engine": {
@@ -2429,6 +2432,31 @@
         }
       },
       {
+        "key": "vl_suppressed",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "vl_suppressed",
+        "type": "native_radio",
+        "label": "Is the child VL suppressed? (less than 1000 copies/ml)",
+        "options": [
+          {
+            "key": "Yes",
+            "text": "Yes"
+          },
+          {
+            "key": "No",
+            "text": "No"
+          }
+        ],
+        "relevance": {
+          "step4:vl_last_result": {
+            "type": "string",
+            "ex": "equalTo(., \"Less than 1000 copies/ml\")"
+          }
+        }
+      },
+
+      {
         "key": "date_next_vl",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
@@ -2473,9 +2501,7 @@
           {
             "key": "no",
             "text": "No",
-            "value": false,
-            "label_info_title": "Child on MMD",
-            "label_info_text": "Check to mean 'No' for MMD"
+            "value": false
           }
         ],
         "v_required": {
@@ -2579,11 +2605,11 @@
         "label": "Caregiver's Gender",
         "options": [
           {
-            "key": "male",
+            "key": "Male",
             "text": "Male"
           },
           {
-            "key": "female",
+            "key": "Female",
             "text": "Female"
           }
         ],

--- a/opensrp-ecap-chw/src/ecap/assets/rule/hh_screening_calculation.yml
+++ b/opensrp-ecap-chw/src/ecap/assets/rule/hh_screening_calculation.yml
@@ -5,3 +5,10 @@ priority: 1
 condition: "step1_sub_population.contains('subpop1')"
 actions:
   - "calculation = subpop1"
+---
+name: step1_vl_suppressed
+description: vl_suppressed
+priority: 1
+condition: "step1_vl_suppressed == ''"
+actions:
+  - "calculation = step1_vl_last_result.contains('Less than 1000 copies/ml')"

--- a/opensrp-ecap-chw/src/ecap/assets/rule/hh_screening_relevance.yml
+++ b/opensrp-ecap-chw/src/ecap/assets/rule/hh_screening_relevance.yml
@@ -138,3 +138,10 @@ priority: 1
 condition: "step3_e_relationship.contains('other')"
 actions:
   - "isRelevant = true"
+---
+name: step3_marriage_partner_name
+description: marriage_partner_name
+priority: 1
+condition: "step3_marital_status.contains('married') || step3_marital_status.contains('in_relationship') "
+actions:
+  - "isRelevant = true"


### PR DESCRIPTION
Ensure on Gender picked on the profile starts with Capital letter Male or Female #602
If the VCA falls under the subpopulation of C/ALHIV and the user selected the option "Yes" on "Is the child/Adolescent currently on treatment?" Then when we come to the question "Is the child currently on ART" on enrollment into OVC program. This question should be prefilled with the option "Yes" because we have already said "Yes" to the question "Is the Child/Adolescent currently on HIV treatment?" under the subpop C/ALHIV #599 (WIP)
The field "Ward" on index VCA screening should be provided by the user. Change this field from read only, allow the user to provide the name of the ward #601
Ensure the field "Address" is prefilled once information has been provided. Ensure the section enrollment into OVC is also working correctly on VCA screening which also for a user to be able to edit data. #603
On household screening the following fields were skipped. #605 (WIP)
If a user does not provide information that is required, on the attention box let the user know which fields were accidentally omitted than just listing "required". This may end up confusing the user. #607
If the option "Married" and "Not married, in a relationship" is selected on marital status then get the full names of the spouse #609
Remove the closing brace on the field "Are there any reasons you may be at risk for HIV?" on household screening. This field shows up if the primary caregiver is HIV negative #604