### PR TITLE
Issue 712: Issues opened on Household screening and Enrollment

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening_entry.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening_entry.json
@@ -332,13 +332,16 @@
         "openmrs_entity_id": "subTown",
         "type": "edit_text",
         "hint": "Ward",
-        "value": "Choma Central",
-        "read_only": "true",
+        "read_only": "false",
         "edit_type": "name",
         "look_up": "true",
         "v_required": {
           "value": true,
           "err": "Ward is Required"
+        },
+        "v_regex": {
+          "value": "[A-Za-z0-9\\s]*",
+          "err": "Ward only accepts letters and digits"
         }
       },
       {
@@ -394,6 +397,18 @@
         "v_required": {
           "value": true,
           "err": "Village is Required"
+        }
+      },
+      {
+        "key": "landmark",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "landmark",
+        "type": "edit_text",
+        "hint": "Nearest Landmark",
+        "v_required": {
+          "value": true,
+          "err": "Nearest landmark is Required"
         }
       },
       {
@@ -1391,11 +1406,11 @@
         "openmrs_entity": "person_attribute",
         "openmrs_entity_id": "spouse_name",
         "type": "edit_text",
-        "hint": "Spouse Name",
+        "hint": "Spouse/Partner Name",
         "edit_type": "name",
         "v_regex": {
           "value": "[A-Za-z\\s\\.\\-]*",
-          "err": "Please enter spouse name"
+          "err": "Please enter spouse/partner name"
         },
         "relevance": {
           "rules-engine": {


### PR DESCRIPTION
…ded on 09/03/2022 #712:  When the option married or not married, in a relationship is selected, allow the user to enter the name of the "Spouse".

                                                                                              The field "Is the child in school?" should not show on a child who is below the age of 5.
                                                                                              Remove the immunization status page for a VCA who is above the age of 2 years.
                                                                                              Allow the user to enter the caregiver's NRC, if the entry point is from the Household register.
                                                                                              Below Home Address add a new field "Nearest Landmark" Which will have to be prefilled on VCA screening
                                                                                              Allow the user to enter "Ward" if the entry point is HH screening.