### PR TITLE
Resolved the following issues

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening.json
@@ -662,7 +662,7 @@
           }
         },
         "v_required": {
-          "value": true,
+          "value": false,
           "err": "Caregiver ART number is Required"
         }
       },
@@ -696,7 +696,7 @@
           "err": "Viral load can only contain numbers"
         },
         "v_required": {
-          "value": true,
+          "value": false,
           "err": "This is a Required field."
         },
         "relevance": {
@@ -758,7 +758,7 @@
           }
         },
         "v_required": {
-          "value": true,
+          "value": false,
           "err": "This is a Required field."
         }
       },

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/vca_screening.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/vca_screening.json
@@ -2602,6 +2602,10 @@
           "value": true,
           "err": "Name of caregiver is required"
         },
+        "v_regex": {
+          "value": "[A-Za-z \\s\\.\\-]* [A-Za-z \\s\\.\\-]*",
+          "err": "Please enter a valid name"
+        },
         "relevance": {
           "rules-engine": {
             "ex-rules": {


### PR DESCRIPTION
-Caregiver’s full name should only allow letters. Currently the Caregiver’s Full Name is allowing both letters and numbers.
-ART and VL fields should not be required on HH screening form #731