### PR TITLE
Issue549 vulnerability assessment

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/json.form/vca_assessment.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/vca_assessment.json
@@ -230,6 +230,12 @@
         "openmrs_entity_id": "date_started_art",
         "type": "date_picker",
         "hint": "When was the VCA initiated on ART?",
+        "relevance": {
+          "step1:is_on_hiv_treatment": {
+            "type": "string",
+            "ex": "equalTo(., \"yes\")"
+          }
+        },
         "expanded": false,
         "duration": {
           "label": ""

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/vca_assessment.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/vca_assessment.json
@@ -151,7 +151,7 @@
         "openmrs_entity_id": "is_hiv_positive",
         "type": "native_radio",
         "label": "HIV status",
-        "read_only": true,
+        "read_only": false,
         "options": [
           {
             "key": "yes",
@@ -174,17 +174,15 @@
         "openmrs_entity_id": "is_on_hiv_treatment",
         "type": "native_radio",
         "label": "Is the VCA on ART?",
-        "read_only": true,
+        "read_only": false,
         "options": [
           {
             "key": "yes",
-            "text": "Yes",
-            "value": false
+            "text": "Yes"
           },
           {
             "key": "no",
-            "text": "No",
-            "value": false
+            "text": "No"
           }
         ],
         "relevance": {
@@ -236,18 +234,12 @@
         "duration": {
           "label": ""
         },
-        "read_only": true,
+        "read_only": false,
         "min_date": "today-100y",
         "max_date": "today",
         "v_required": {
           "value": false,
           "err": "When was the VCA initiated on ART"
-        },
-        "relevance": {
-          "step1:is_on_hiv_treatment": {
-            "type": "string",
-            "ex": "equalTo(., \"yes\")"
-          }
         }
       },
       {

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/vca_assessment.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/vca_assessment.json
@@ -151,7 +151,7 @@
         "openmrs_entity_id": "is_hiv_positive",
         "type": "native_radio",
         "label": "HIV status",
-        "read_only": false,
+        "read_only": true,
         "options": [
           {
             "key": "yes",
@@ -174,7 +174,7 @@
         "openmrs_entity_id": "is_on_hiv_treatment",
         "type": "native_radio",
         "label": "Is the VCA on ART?",
-        "read_only": false,
+        "read_only": true,
         "options": [
           {
             "key": "yes",
@@ -234,7 +234,7 @@
         "duration": {
           "label": ""
         },
-        "read_only": false,
+        "read_only": true,
         "min_date": "today-100y",
         "max_date": "today",
         "v_required": {


### PR DESCRIPTION
On index screening if the HIV status for a VCA is positive and the VCA is on ART and the Date when the VCA was initiated on ART has been provided in the enrollment into OVC. Then this information should be prepopulated on Vulnerability Assessment. #549