### PR TITLE
Resolve high priority issues in issue 791

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/json.form/family_member.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/family_member.json
@@ -194,6 +194,9 @@
         "max_date": "today",
         "min_date": "today-100y",
         "hint": "Date of birth",
+        "duration": {
+          "label": "Age"
+        },
         "v_required": {
           "value": true,
           "err": "Date of birth is Required"

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening_entry.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/hh_screening_entry.json
@@ -1085,14 +1085,6 @@
         "value": "true"
       },
       {
-        "key": "is_hiv_positive",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "is_hiv_positive",
-        "type": "hidden",
-        "value": "yes"
-      },
-      {
         "key": "subpop1_toast",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/CaregiverDao.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/CaregiverDao.java
@@ -1,7 +1,6 @@
 package com.bluecodeltd.ecap.chw.dao;
 
 import com.bluecodeltd.ecap.chw.model.Caregiver;
-import com.bluecodeltd.ecap.chw.model.Household;
 
 import org.smartregister.dao.AbstractDao;
 
@@ -11,7 +10,7 @@ public class CaregiverDao extends AbstractDao {
 
     public static Caregiver getCaregiver (String householdID) {
 
-        String sql = "SELECT caregiver_name, caregiver_nrc, caregiver_sex, caregiver_birth_date, caregiver_phone, caregiver_hiv_status, caregiver_art_number, active_on_treatment, relation FROM ec_household WHERE ec_household.household_id = '" + householdID + "' ";
+        String sql = "SELECT caregiver_name, ward, caregiver_nrc, caregiver_sex, caregiver_birth_date, caregiver_phone, caregiver_hiv_status, caregiver_art_number, active_on_treatment, relation FROM ec_household WHERE ec_household.household_id = '" + householdID + "' ";
 
         List<Caregiver> values = AbstractDao.readData(sql, getCaregiverMap());
 
@@ -25,6 +24,7 @@ public class CaregiverDao extends AbstractDao {
             Caregiver record = new Caregiver();
 
             record.setCaregiver_name(getCursorValue(c, "caregiver_name"));
+            record.setWard(getCursorValue(c, "ward"));
             record.setCaregiver_nrc(getCursorValue(c, "caregiver_nrc"));
             record.setCaregiver_sex(getCursorValue(c, "caregiver_sex"));
             record.setCaregiver_birth_date(getCursorValue(c, "caregiver_birth_date"));

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/Caregiver.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/Caregiver.java
@@ -12,6 +12,15 @@ public class Caregiver {
     private String active_on_treatment;
     private String caregiver_art_number;
     private String relation;
+    private String ward;
+
+    public String getWard() {
+        return ward;
+    }
+
+    public void setWard(String ward) {
+        this.ward = ward;
+    }
 
     public String getCaregiver_name() {
         return caregiver_name;

--- a/opensrp-ecap-chw/src/main/res/layout/vca_content.xml
+++ b/opensrp-ecap-chw/src/main/res/layout/vca_content.xml
@@ -409,7 +409,7 @@
                     android:gravity="center"
                     android:minWidth="50dp"
                     android:padding="10dp"
-                    android:text="Household Visitation"
+                    android:text="Follow-up Visitation"
                     android:textStyle="italic"
                      />
 


### PR DESCRIPTION
- If the subpopulation for the VCA on Index VCA screening is “HEI” so this means on VCA vulnerability, the status should be negative and not positive
- The field “Ward” should prefill on add family members because this information has been collected already.
- On add family members once the “Date of birth” has been added. The age for that member also shows, similar to how this has been implemented on index VCA screening
-  If the subpopulation for the VCA on Index VCA screening is “HEI” so this means on VCA household visitation, the status should be negative and not positive.
-On the VCA profile change the label on the button “Household visitation” to “Follow-up Visitation”.