### PR TITLE
Resolved issues of the following

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_vca_0_20_years.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_vca_0_20_years.json
@@ -55,7 +55,6 @@
   "step1": {
     "title": "Household Visitation For VCA 0-20 years",
     "fields": [
-
       {
         "key": "unique_id",
         "openmrs_entity_parent": "",
@@ -96,7 +95,6 @@
           "err": "Name of Person can  only contain letters"
         }
       },
-
       {
         "key": "phone",
         "openmrs_entity_parent": "",
@@ -116,7 +114,6 @@
         }
       },
       {
-
         "key": "date_edited_check",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
@@ -204,7 +201,6 @@
           }
         ]
       },
-
       {
         "key": "child_art",
         "openmrs_entity_parent": "",
@@ -257,7 +253,6 @@
           }
         }
       },
-
       {
         "key": "art_appointment",
         "openmrs_entity_parent": "",
@@ -422,7 +417,6 @@
           }
         }
       },
-
       {
         "key": "six_months",
         "openmrs_entity_parent": "",
@@ -449,7 +443,6 @@
           }
         }
       },
-
       {
         "key": "toaster_a",
         "openmrs_entity_parent": "",
@@ -467,7 +460,6 @@
           }
         }
       },
-
       {
         "key": "health_facility",
         "openmrs_entity_parent": "",
@@ -523,10 +515,6 @@
           }
         }
       },
-
-
-
-
       {
         "key": "date_hiv",
         "openmrs_entity_parent": "",
@@ -543,7 +531,6 @@
           }
         }
       },
-
       {
         "key": "visits",
         "openmrs_entity_parent": "",
@@ -622,7 +609,6 @@
           }
         }
       },
-
       {
         "key": "hiv_risk",
         "openmrs_entity_parent": "",
@@ -683,8 +669,6 @@
           }
         }
       },
-
-
       {
         "key": "hiv_assessment",
         "openmrs_entity_parent": "",
@@ -711,7 +695,6 @@
           }
         }
       },
-
       {
         "key": "toaster_b",
         "openmrs_entity_parent": "",
@@ -729,8 +712,6 @@
           }
         }
       },
-
-
       {
         "key": "referred_facility",
         "openmrs_entity_parent": "",
@@ -757,7 +738,6 @@
           }
         }
       },
-
       {
         "key": "spacer",
         "openmrs_entity_parent": "",
@@ -766,7 +746,6 @@
         "type": "spacer",
         "spacer_height": "15dp"
       },
-
       {
         "key": "hd1",
         "openmrs_entity_parent": "",
@@ -775,7 +754,6 @@
         "type": "label",
         "text": "HIV Exposed Infant (VCA aged 24 months and below) Section"
       },
-
       {
         "key": "eid_test",
         "openmrs_entity_parent": "",
@@ -987,8 +965,6 @@
           }
         }
       },
-
-
       {
         "key": "against_hiv_risk",
         "openmrs_entity_parent": "",
@@ -1015,7 +991,6 @@
           }
         }
       },
-
       {
         "key": "referred_health_facility",
         "openmrs_entity_parent": "",
@@ -1094,9 +1069,6 @@
           }
         }
       },
-
-
-
       {
         "key": "hd1",
         "openmrs_entity_parent": "",
@@ -1226,7 +1198,6 @@
           }
         }
       },
-
       {
         "key": "nutrition_counselling_a",
         "openmrs_entity_parent": "",
@@ -1254,7 +1225,6 @@
           }
         }
       },
-
       {
         "key": "heps_a",
         "openmrs_entity_parent": "",
@@ -1282,7 +1252,6 @@
           }
         }
       },
-
       {
         "key": "muac_other_a",
         "openmrs_entity_parent": "",
@@ -1300,7 +1269,6 @@
           }
         }
       },
-
       {
         "key": "muac_measurement_b",
         "openmrs_entity_parent": "",
@@ -1472,7 +1440,6 @@
           }
         ]
       },
-
       {
         "key": "neglected_child_exploitation",
         "openmrs_entity_parent": "",
@@ -1582,8 +1549,6 @@
         "type": "label",
         "text": "Physical Violence Section"
       },
-
-
       {
         "key": "signs_of_violence",
         "openmrs_entity_parent": "",
@@ -1759,8 +1724,6 @@
           }
         }
       },
-
-
       {
         "key": "child_ever_experienced_sexual_violence",
         "openmrs_entity_parent": "",
@@ -1836,7 +1799,6 @@
           }
         }
       },
-
       {
         "key": "parenting_intervention",
         "openmrs_entity_parent": "",
@@ -1880,7 +1842,6 @@
           }
         }
       },
-
       {
         "key": "health_label",
         "openmrs_entity_parent": "",
@@ -1889,7 +1850,6 @@
         "type": "label",
         "text": "Psychosocial Protection"
       },
-
       {
         "key": "child_psychosocial",
         "openmrs_entity_parent": "",
@@ -1981,7 +1941,6 @@
           }
         }
       },
-
       {
         "key": "schooled_label",
         "openmrs_entity_parent": "",
@@ -2012,7 +1971,6 @@
           }
         }
       },
-
       {
         "key": "currently_in_school",
         "openmrs_entity_parent": "",
@@ -2079,7 +2037,6 @@
           }
         }
       },
-
       {
         "key": "verified_by_school_days",
         "openmrs_entity_parent": "",
@@ -2097,7 +2054,6 @@
           }
         }
       },
-
       {
         "key": "challenges_barriers",
         "openmrs_entity_parent": "",
@@ -2125,7 +2081,6 @@
           }
         }
       },
-
       {
         "key": "not_in_school",
         "openmrs_entity_parent": "",
@@ -2152,7 +2107,6 @@
           }
         }
       },
-
       {
         "key": "child_household",
         "openmrs_entity_parent": "",
@@ -2200,7 +2154,6 @@
           }
         }
       },
-
       {
         "key": "grade_progression",
         "openmrs_entity_parent": "",
@@ -2376,60 +2329,6 @@
           }
         ]
       },
-
-
-
-      {
-        "key": "manager_name",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "manager_name",
-        "type": "edit_text",
-        "hint": "Verified by Case Worker Supervisor ",
-        "edit_type": "name",
-        "look_up": "true",
-        "read_only": false,
-        "v_regex": {
-          "value": "[A-Za-z\\s\\.\\-]*",
-          "err": "Please enter a valid name"
-        }
-      },
-      {
-        "key": "manager_date_signed",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "manager_date_signed",
-        "type": "date_picker",
-        "hint": "Date Case Worker Signs",
-        "expanded": false,
-        "duration": {
-          "label": ""
-        },
-        "min_date": "today-100y",
-        "max_date": "today",
-        "v_required": {
-          "value": false,
-          "err": "Date Signed"
-        }
-      },
-      {
-        "key": "manager_signature",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "manager_signature",
-        "type": "check_box",
-        "label": "I hereby confirms that the information I have given is true",
-        "label_text_style": "italic",
-        "options": [
-          {
-            "key": "yes",
-            "text": "Yes",
-            "value": false
-          }
-        ]
-      },
-
-
       {
         "key": "school_administration_name",
         "openmrs_entity_parent": "",
@@ -2523,7 +2422,6 @@
           }
         }
       }
-
     ]
   }
 }

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_household.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_household.json
@@ -71,6 +71,7 @@
         "openmrs_entity_id": "date",
         "type": "date_picker",
         "hint": "Date when Service/s Provided",
+        "read_only": true,
         "v_required": {
           "value": true,
           "err": "This field is required"

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_vca.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_vca.json
@@ -56,6 +56,7 @@
         "openmrs_entity_id": "date",
         "type": "date_picker",
         "hint": "Date when Service/s Provided",
+        "read_only": true,
         "v_required": {
           "value": true,
           "err": "This field is required"

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/IndexDetailsActivity.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/IndexDetailsActivity.java
@@ -105,6 +105,10 @@ import es.dmoral.toasty.Toasty;
 import timber.log.Timber;
 
 public class IndexDetailsActivity extends AppCompatActivity {
+    @Override
+    protected void onResume() {
+        super.onResume();
+    }
 
     private FloatingActionButton fab, fabHiv,fabHiv2, fabGradSub, fabGrad, fabCasePlan, fabVisitation, fabReferal,  fabAssessment;
     private Animation fab_open,fab_close,rotate_forward,rotate_backward;
@@ -300,6 +304,7 @@ public class IndexDetailsActivity extends AppCompatActivity {
     }
 
 
+
     private String getAgeWithoutText(String birthdate){
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-u");
         LocalDate localDateBirthdate = LocalDate.parse(birthdate, formatter);
@@ -473,7 +478,7 @@ public class IndexDetailsActivity extends AppCompatActivity {
                 if(indexVCA.getDate_screened() != null) {
 
                     Intent intent2 = new Intent(this, VcaServiceActivity.class);
-                    intent2.putExtra("vcaid", indexVCA.getHousehold_id());
+                    intent2.putExtra("vcaid", indexVCA.getUnique_id());
                     intent2.putExtra("hivstatus", indexVCA.getIs_hiv_positive());
                     intent2.putExtra("vcaname", txtName.getText().toString());
                     startActivity(intent2);
@@ -569,23 +574,25 @@ public class IndexDetailsActivity extends AppCompatActivity {
                 saveRegistration(childIndexEventClient, is_edit_mode);
               //  getUniqueIdRepository().close(uniqueId);
 
-
-                Toasty.success(IndexDetailsActivity.this, "Form Saved", Toast.LENGTH_LONG, true).show();
                 if(encounterType.equals("VCA Case Plan"))
                 {
 
                     JSONObject cpdate = getFieldJSONObject(fields(jsonFormObject, "step1"), "case_plan_date");
                     String dateId = cpdate.optString("value");
+                    finish();
+                    startActivity(getIntent());
                     openVcaCasplanToAddVulnarabilities(dateId);
+
+
+                }
+                if(encounterType.equals("Household Visitation Form 0-20 years"))
+                {
                     finish();
                     startActivity(getIntent());
 
                 }
-                else {
-                    finish();
-                    startActivity(getIntent());
+                Toasty.success(IndexDetailsActivity.this, "Form Saved", Toast.LENGTH_LONG, true).show();
 
-                }
             } catch (Exception e) {
                 Timber.e(e);
             }
@@ -1047,18 +1054,7 @@ public class IndexDetailsActivity extends AppCompatActivity {
 
                 case "household_visitation_for_vca_0_20_years":
 
-                if(vcaVisitationModel == null){
-
-                    //Pulls data for populating from indexchild when adding data for the very first time
                     CoreJsonFormUtils.populateJsonForm(formToBeOpened, oMapper.convertValue(indexVCA, Map.class));
-                    formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(1).put("value", vcaAge);
-
-                } else {
-
-                    formToBeOpened.put("entity_id", this.vcaVisitationModel.getBase_entity_id());
-                    CoreJsonFormUtils.populateJsonForm(formToBeOpened, oMapper.convertValue(vcaVisitationModel, Map.class));
-                    formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(1).put("value", vcaAge);
-                }
                 break;
 
             case "referral":
@@ -1213,10 +1209,12 @@ public class IndexDetailsActivity extends AppCompatActivity {
         return super.onOptionsItemSelected(item);
     }
 
+
     @Override
     public void onBackPressed() {
         super.onBackPressed();
         this.finish();
 
     }
+
 }

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/HouseholdServiceAdapter.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/HouseholdServiceAdapter.java
@@ -3,7 +3,6 @@ package com.bluecodeltd.ecap.chw.adapter;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
-import android.text.format.DateFormat;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -13,16 +12,7 @@ import android.widget.TextView;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bluecodeltd.ecap.chw.R;
-import com.bluecodeltd.ecap.chw.activity.CasePlan;
-import com.bluecodeltd.ecap.chw.activity.HouseholdServiceActivity;
-import com.bluecodeltd.ecap.chw.dao.CasePlanDao;
-import com.bluecodeltd.ecap.chw.dao.GradDao;
-import com.bluecodeltd.ecap.chw.dao.HouseholdDao;
-import com.bluecodeltd.ecap.chw.dao.MuacDao;
-import com.bluecodeltd.ecap.chw.model.CasePlanModel;
-import com.bluecodeltd.ecap.chw.model.Child;
 import com.bluecodeltd.ecap.chw.model.FamilyServiceModel;
-import com.bluecodeltd.ecap.chw.model.GradModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
 
@@ -34,9 +24,6 @@ import org.smartregister.client.utils.domain.Form;
 import org.smartregister.family.util.JsonFormUtils;
 import org.smartregister.util.FormUtils;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -152,8 +139,7 @@ public class HouseholdServiceAdapter extends RecyclerView.Adapter<HouseholdServi
 
         formToBeOpened = formUtils.getFormJson(formName);
 
-        formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(1).put("read_only", true);
-
+        formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(1).remove("read_only");
         formToBeOpened.put("entity_id", service.getBase_entity_id());
 
         CoreJsonFormUtils.populateJsonForm(formToBeOpened, oMapper.convertValue(service, Map.class));

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/VCAServiceAdapter.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/VCAServiceAdapter.java
@@ -12,8 +12,6 @@ import android.widget.TextView;
 import androidx.recyclerview.widget.RecyclerView;
 
 import com.bluecodeltd.ecap.chw.R;
-import com.bluecodeltd.ecap.chw.activity.HouseholdServiceActivity;
-import com.bluecodeltd.ecap.chw.activity.VcaServiceActivity;
 import com.bluecodeltd.ecap.chw.model.VCAServiceModel;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.vijay.jsonwizard.constants.JsonFormConstants;
@@ -121,7 +119,7 @@ public class VCAServiceAdapter  extends RecyclerView.Adapter<VCAServiceAdapter.V
 
         formToBeOpened = formUtils.getFormJson(formName);
 
-        formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(0).put("read_only", true);
+        formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(0).remove("read_only");
 
         formToBeOpened.put("entity_id", service.getBase_entity_id());
 


### PR DESCRIPTION
-The date when service was provided should also be editable on service report #859
-On the family member am able to see the services which were offered to the Index VCA which should not be the case #860
-When the second follow visit has been conducted let it been displayed on the visits and should be editable. Right now we are only seeing one visit even when a more than one visit has been conducted #861
-When one adds a vulnerability on the family member, the vulnerability does not show immediately. For it to be seen one has to leave the page and then goes back which should not be the case #862
-The fields Verified by caseworker supervisor and date supervisor signs should be removed from the follow up visit forms #863
-When adding a new visit the user does not need to see the old data that was added, the form should be blank. If the see information users will think it is editing when it is actually adding a new visit #864
-Make the date editable on the service report that is on the household profile #866
