### PR TITLE
Resolved the following issues

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_household.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_household.json
@@ -71,7 +71,6 @@
         "openmrs_entity_id": "date",
         "type": "date_picker",
         "hint": "Date when Service/s Provided",
-        "read_only": true,
         "v_required": {
           "value": true,
           "err": "This field is required"

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_vca.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_vca.json
@@ -56,7 +56,6 @@
         "openmrs_entity_id": "date",
         "type": "date_picker",
         "hint": "Date when Service/s Provided",
-        "read_only": true,
         "v_required": {
           "value": true,
           "err": "This field is required"

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/IndexDetailsActivity.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/IndexDetailsActivity.java
@@ -591,11 +591,18 @@ public class IndexDetailsActivity extends AppCompatActivity {
                     startActivity(getIntent());
 
                 }
+                if(encounterType.equals("Member Sub Population"))
+                {
+                    finish();
+                    startActivity(getIntent());
+
+                }
                 Toasty.success(IndexDetailsActivity.this, "Form Saved", Toast.LENGTH_LONG, true).show();
 
             } catch (Exception e) {
                 Timber.e(e);
             }
+
 
         }
 

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/HouseholdServiceAdapter.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/HouseholdServiceAdapter.java
@@ -139,7 +139,7 @@ public class HouseholdServiceAdapter extends RecyclerView.Adapter<HouseholdServi
 
         formToBeOpened = formUtils.getFormJson(formName);
 
-        formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(1).remove("read_only");
+        formToBeOpened.getJSONObject("step1").getJSONArray("fields").getJSONObject(0).remove("read_only");
         formToBeOpened.put("entity_id", service.getBase_entity_id());
 
         CoreJsonFormUtils.populateJsonForm(formToBeOpened, oMapper.convertValue(service, Map.class));


### PR DESCRIPTION
-The field Date when services was provided is not clickable on the VCA service report. - Entry point used household register #881
-If the entry point used is house register and the user has conducted the VCA screening then when the user clicks on Vulnerability the pop up VCA screening has not be conducted should not show. For now the user has to leave the page then go back that is when Vulnerability assessment is opening. #880
-The user enter anything on date when the service was provided because it is grayed out. Make sure the user can provide the date - This is on Service report on household profile #876
