### PR TITLE
Resolved

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/ec_client_fields.json
+++ b/opensrp-ecap-chw/src/ecap/assets/ec_client_fields.json
@@ -6749,6 +6749,27 @@
           "json_mapping": {
             "field": "attributes.safety_plans"
           }
+        },
+        {
+          "column_name": "stateWhen",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.stateWhen"
+          }
+        },
+        {
+          "column_name": "frequency",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.frequency"
+          }
+        },
+        {
+          "column_name": "who",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.who"
+          }
         }
       ]
     }

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/child_safety_action.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/child_safety_action.json
@@ -124,10 +124,60 @@
       {
         "key": "safety_plans",
         "openmrs_entity_parent": "",
+        "openmrs_entity": "",
+        "openmrs_entity_id": "",
+        "type": "toaster_notes",
+        "text": "To know how these actions for monitoring plans will be confirmed kindly state  when, frequency and who",
+        "toaster_type": "info",
+        "toaster_info_text": "",
+        "toaster_info_title": "Information Toaster Info Title",
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "child_safety_plan.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "stateWhen",
+        "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "safety_plans",
+        "openmrs_entity_id": "stateWhen",
         "type": "edit_text",
-        "hint": "MONITORING PLANS:\nHow will these actions be confirmed",
+        "hint": "State When",
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "child_safety_plan.yml"
+            }
+          }
+        }
+
+      },
+      {
+        "key": "frequency",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "frequency",
+        "type": "edit_text",
+        "hint": "State Frequency",
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "child_safety_plan.yml"
+            }
+          }
+        }
+      },
+      {
+        "key": "who",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "who",
+        "type": "edit_text",
+        "input_type": "name",
+        "hint": "By Who",
         "relevance": {
           "rules-engine": {
             "ex-rules": {

--- a/opensrp-ecap-chw/src/ecap/assets/rule/child_safety_plan.yml
+++ b/opensrp-ecap-chw/src/ecap/assets/rule/child_safety_plan.yml
@@ -19,3 +19,24 @@ priority: 1
 condition: "step1_safety_protection != '' "
 actions:
   - "isRelevant = true"
+---
+name: step1_stateWhen
+description: plans
+priority: 1
+condition: "step1_safety_protection != '' "
+actions:
+  - "isRelevant = true"
+---
+name: step1_frequency
+description: plans
+priority: 1
+condition: "step1_stateWhen != '' "
+actions:
+  - "isRelevant = true"
+---
+name: step1_who
+description: plans
+priority: 1
+condition: "step1_frequency != '' "
+actions:
+  - "isRelevant = true"

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/ChildSafetyPlanActions.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/ChildSafetyPlanActions.java
@@ -109,14 +109,14 @@ public class ChildSafetyPlanActions extends AppCompatActivity {
 
                     indexRegisterForm = formUtils.getFormJson("child_safety_action");
 
-                   // indexRegisterForm.getJSONObject("step1").getJSONArray("fields").getJSONObject(0).put("value", childId);
+                    // indexRegisterForm.getJSONObject("step1").getJSONArray("fields").getJSONObject(0).put("value", childId);
                     indexRegisterForm.getJSONObject("step1").getJSONArray("fields").getJSONObject(1).put("value", actionDate);
 
                     JSONObject cId = getFieldJSONObject(fields(indexRegisterForm, STEP1), "unique_id");
                     cId.put("value",childId);
 
-                   // JSONObject cDate = getFieldJSONObject(fields(indexRegisterForm, STEP1), "case_plan_date");
-                   // cDate.put("value", actionDate);
+                    // JSONObject cDate = getFieldJSONObject(fields(indexRegisterForm, STEP1), "case_plan_date");
+                    // cDate.put("value", actionDate);
 
                     startFormActivity(indexRegisterForm);
 

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/ChildSafetyPlanActivity.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/ChildSafetyPlanActivity.java
@@ -109,8 +109,12 @@ public class ChildSafetyPlanActivity extends AppCompatActivity {
     @Override
     public void onResume() {
         super.onResume();
+        childSafetyPlanList.addAll(ChildSafetyPlanDao.getChildSafetyPlanModel(intent_vcaid));
+        recyclerViewadapter = new ChildSafetyPlanAdapter(childSafetyPlanList, ChildSafetyPlanActivity.this);
         recyclerView.setAdapter(recyclerViewadapter);
         recyclerViewadapter.notifyDataSetChanged();
+
+
     }
 
     @SuppressLint("NonConstantResourceId")
@@ -160,14 +164,26 @@ public class ChildSafetyPlanActivity extends AppCompatActivity {
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
 
+
         super.onActivityResult(requestCode, resultCode, data);
 
         if (requestCode == JsonFormUtils.REQUEST_CODE_GET_JSON && resultCode == RESULT_OK) {
 
-
+            boolean is_edit_mode = false;
 
             String jsonString = data.getStringExtra(JsonFormConstants.JSON_FORM_KEY.JSON);
 
+            JSONObject jsonFormObject = null;
+            try {
+                jsonFormObject = new JSONObject(jsonString);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+            String encounterType = jsonFormObject.optString(JsonFormConstants.ENCOUNTER_TYPE, "");
+
+            if(!jsonFormObject.optString("entity_id").isEmpty()){
+                is_edit_mode = true;
+            }
 
             try {
 
@@ -177,17 +193,24 @@ public class ChildSafetyPlanActivity extends AppCompatActivity {
                     return;
                 }
 
-                saveRegistration(childIndexEventClient, false);
+                saveRegistration(childIndexEventClient, is_edit_mode);
 
-                Toasty.success(ChildSafetyPlanActivity.this, "Child Safety Plan Saved", Toast.LENGTH_LONG, true).show();
+                JSONObject cpdate = getFieldJSONObject(fields(jsonFormObject, "step1"), "initial_date");
+                String dateId = cpdate.optString("value");
+                openChildSafetyPlanAction(dateId);
+                if(encounterType.equals("Child Safety Plan"))
+                {
+
+
+                }
 
 
             } catch (Exception e) {
                 Timber.e(e);
             }
         }
-        finish();
-        startActivity(getIntent());
+        //  finish();
+        //  startActivity(getIntent());
     }
 
     public ChildIndexEventClient processRegistration(String jsonString){
@@ -321,4 +344,17 @@ public class ChildSafetyPlanActivity extends AppCompatActivity {
         }
 
     }
+    public void openChildSafetyPlanAction(String dateId) {
+
+        Intent i = new Intent(ChildSafetyPlanActivity.this, ChildSafetyPlanActions.class);
+        Bundle bundle = new Bundle();
+        bundle.putString("child_ID", intent_vcaid);
+        bundle.putString("action_date",dateId);
+        i.putExtras(bundle);
+        startActivity(i);
+        Toasty.success(ChildSafetyPlanActivity.this, "Child Safety Plan Saved", Toast.LENGTH_LONG, true).show();
+
+
+    }
+
 }

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ChildSafetyActionAdapter.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ChildSafetyActionAdapter.java
@@ -63,7 +63,9 @@ public class ChildSafetyActionAdapter extends RecyclerView.Adapter<ChildSafetyAc
         holder.txtSafetyThreats.setText(plan.getSafety_threats());
         holder.txtSafetyAction.setText(plan.getSafety_action());
         holder.txtSafetyProtection.setText(plan.getSafety_protection());
-        holder.txtSafetyPlans.setText(plan.getSafety_plans());
+        holder.txtWhen.setText(plan.getStateWhen());
+        holder.txtFrequency.setText(plan.getFrequency());
+        holder.txtWho.setText(plan.getWho());
         holder.txtActionDate.setText("Date Created : " + plan.getInitial_date());
 
 
@@ -166,7 +168,7 @@ public class ChildSafetyActionAdapter extends RecyclerView.Adapter<ChildSafetyAc
 
     class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
 
-        TextView  txtSafetyThreats,txtSafetyAction,txtSafetyProtection,txtSafetyPlans,txtActionDate;
+        TextView  txtSafetyThreats,txtSafetyAction,txtSafetyProtection,txtWhen,txtFrequency,txtWho,txtActionDate;
 
         LinearLayout linearLayout, exPandableView;
 
@@ -184,7 +186,9 @@ public class ChildSafetyActionAdapter extends RecyclerView.Adapter<ChildSafetyAc
             txtSafetyThreats = itemView.findViewById(R.id.safetyThreats);
             txtSafetyAction = itemView.findViewById(R.id.safetyAction);
             txtSafetyProtection = itemView.findViewById(R.id.safetyProtection);
-            txtSafetyPlans = itemView.findViewById(R.id.safetyPlans);
+            txtWhen = itemView.findViewById(R.id.when);
+            txtFrequency = itemView.findViewById(R.id.frequency);
+            txtWho = itemView.findViewById(R.id.who);
             txtActionDate = itemView.findViewById(R.id.initial_date);
 
         }

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/ChildSafetyActionDao.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/ChildSafetyActionDao.java
@@ -44,6 +44,9 @@ public class ChildSafetyActionDao extends AbstractDao {
             record.setSafety_plans(getCursorValue(c, "safety_plans"));
             record.setBase_entity_id(getCursorValue(c, "base_entity_id"));
             record.setInitial_date(getCursorValue(c,"initial_date"));
+            record.setStateWhen(getCursorValue(c, "stateWhen"));
+            record.setFrequency(getCursorValue(c, "frequency"));
+            record.setWho(getCursorValue(c,"who"));
             record.setUnique_id(getCursorValue(c,"unique_id"));
 
             return record;

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/ChildSafetyActionModel.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/ChildSafetyActionModel.java
@@ -7,23 +7,10 @@ public class ChildSafetyActionModel {
     private String safety_plans;
     private String initial_date;
     private String base_entity_id;
+    private String who;
+    private String stateWhen;
+    private String frequency;
     private String unique_id;
-
-    public String getInitial_date() {
-        return initial_date;
-    }
-
-    public void setInitial_date(String initial_date) {
-        this.initial_date = initial_date;
-    }
-
-    public String getUnique_id() {
-        return unique_id;
-    }
-
-    public void setUnique_id(String unique_id) {
-        this.unique_id = unique_id;
-    }
 
     public String getSafety_threats() {
         return safety_threats;
@@ -57,11 +44,51 @@ public class ChildSafetyActionModel {
         this.safety_plans = safety_plans;
     }
 
+    public String getInitial_date() {
+        return initial_date;
+    }
+
+    public void setInitial_date(String initial_date) {
+        this.initial_date = initial_date;
+    }
+
     public String getBase_entity_id() {
         return base_entity_id;
     }
 
     public void setBase_entity_id(String base_entity_id) {
         this.base_entity_id = base_entity_id;
+    }
+
+    public String getWho() {
+        return who;
+    }
+
+    public void setWho(String who) {
+        this.who = who;
+    }
+
+    public String getStateWhen() {
+        return stateWhen;
+    }
+
+    public void setStateWhen(String stateWhen) {
+        this.stateWhen = stateWhen;
+    }
+
+    public String getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(String frequency) {
+        this.frequency = frequency;
+    }
+
+    public String getUnique_id() {
+        return unique_id;
+    }
+
+    public void setUnique_id(String unique_id) {
+        this.unique_id = unique_id;
     }
 }

--- a/opensrp-ecap-chw/src/main/res/layout/single_action_plan.xml
+++ b/opensrp-ecap-chw/src/main/res/layout/single_action_plan.xml
@@ -214,12 +214,56 @@
             <TextView
                 android:layout_weight="1"
                 android:textStyle="bold"
-                android:text="Safety Plans"
+                android:text="When"
                 android:layout_width="0dip"
                 android:layout_height="wrap_content"/>
 
             <TextView
-                android:id="@+id/safetyPlans"
+                android:id="@+id/when"
+                android:layout_weight="1"
+                android:text="yhs dgbdfbhdh"
+                android:layout_width="0dip"
+                android:layout_height="wrap_content"/>
+
+        </LinearLayout>
+        <LinearLayout
+            android:layout_marginTop="5dp"
+            android:weightSum="2"
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_weight="1"
+                android:textStyle="bold"
+                android:text="Frequency"
+                android:layout_width="0dip"
+                android:layout_height="wrap_content"/>
+
+            <TextView
+                android:id="@+id/frequency"
+                android:layout_weight="1"
+                android:text="yhs dgbdfbhdh"
+                android:layout_width="0dip"
+                android:layout_height="wrap_content"/>
+
+        </LinearLayout>
+        <LinearLayout
+            android:layout_marginTop="5dp"
+            android:weightSum="2"
+            android:orientation="horizontal"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
+
+            <TextView
+                android:layout_weight="1"
+                android:textStyle="bold"
+                android:text="Who"
+                android:layout_width="0dip"
+                android:layout_height="wrap_content"/>
+
+            <TextView
+                android:id="@+id/who"
                 android:layout_weight="1"
                 android:text="yhs dgbdfbhdh"
                 android:layout_width="0dip"


### PR DESCRIPTION
 -When a user clicks on the child safety plan and saves, the page should redirect to “Add Actions” instead of the safety plan. The implementation should be the same as that of a case plan.
- On monitoring plans on the child safety plans, make sure we are capturing information on when these actions will be confirmed, frequency and by who.