### PR TITLE
Fix issues created from the last build shared on 03/08/2022. #925

### DIFF
--- a/opensrp-ecap-chw/src/ecap/assets/ec_client_fields.json
+++ b/opensrp-ecap-chw/src/ecap/assets/ec_client_fields.json
@@ -3680,10 +3680,10 @@
           }
         },
         {
-          "column_name": "date_referred",
+          "column_name": "referred_date",
           "type": "Client",
           "json_mapping": {
-            "field": "attributes.date_referred"
+            "field": "attributes.referred_date"
           }
         },
         {
@@ -6608,6 +6608,68 @@
           "type": "Client",
           "json_mapping": {
             "field": "attributes.caregiver_question"
+          }
+        }
+      ]
+    },
+    {
+      "name": "ec_household_service_report",
+      "columns": [
+
+        {
+          "column_name": "services",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.services"
+          }
+        },
+        {
+          "column_name": "services_household",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.services_household"
+          }
+        },
+        {
+          "column_name": "services_caregiver",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.services_caregiver"
+          }
+        },
+        {
+          "column_name": "date",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.date"
+          }
+        },
+        {
+          "column_name": "household_id",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.household_id"
+          }
+        },
+        {
+          "column_name": "base_entity_id",
+          "type": "Client",
+          "json_mapping": {
+            "field": "baseEntityId"
+          }
+        },
+        {
+          "column_name": "other_services_caregiver",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.other_services_caregiver"
+          }
+        },
+        {
+          "column_name": "other_services_household",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.other_services_household"
           }
         }
       ]

--- a/opensrp-ecap-chw/src/ecap/assets/ec_client_fields.json
+++ b/opensrp-ecap-chw/src/ecap/assets/ec_client_fields.json
@@ -1508,7 +1508,7 @@
           }
         },
         {
-          "column_name": "school_name",
+          "column_name": "schoolName",
           "type": "Client",
           "json_mapping": {
             "field": "attributes.schoolName"
@@ -3656,6 +3656,13 @@
           "type": "Client",
           "json_mapping": {
             "field": "attributes.unique_id"
+          }
+        },
+        {
+          "column_name": "household_id",
+          "type": "Client",
+          "json_mapping": {
+            "field": "attributes.household_id"
           }
         },
         {

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/family_member.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/family_member.json
@@ -59,7 +59,7 @@
         "key": "province",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "stateProvince",
+        "openmrs_entity_id": "province",
         "type": "edit_text",
         "hint": "Province",
         "read_only": "true",
@@ -139,6 +139,16 @@
         "hint": "VCA ID",
         "edit_type": "name"
       },
+      {
+        "key": "landmark",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "landmark",
+        "type": "edit_text",
+        "hint": "Nearest Landmark",
+        "read_only": true
+      },
+
       {
         "key": "member_type",
         "openmrs_entity_parent": "",
@@ -344,6 +354,24 @@
         "openmrs_entity": "person_attribute",
         "openmrs_entity_id": "fsw",
         "type": "hidden"
+      },
+      {
+        "key": "phone",
+        "openmrs_entity_parent": "",
+        "openmrs_entity": "person_attribute",
+        "openmrs_entity_id": "phone",
+        "type": "hidden",
+        "hint": "Caseworker Phone",
+        "edit_type": "number",
+        "read_only": true,
+        "v_numeric": {
+          "value": false,
+          "err": "Number must begin with 077,076,095, 096, or 097 and must be a total of 10 digits in length"
+        },
+        "v_regex": {
+          "value": "((07||09)[5-7][0-9]{7})|s*",
+          "err": "Number must begin with 077,076,095, 096, or 097 and must be a total of 10 digits in length"
+        }
       }
     ]
   },

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/grad.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/grad.json
@@ -138,6 +138,13 @@
         "v_required": {
           "value": true,
           "err": "This field is required"
+        },
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "grad_relevance.yml"
+            }
+          }
         }
       },
       {
@@ -235,7 +242,8 @@
         "options": [
           {
             "key": "yes",
-            "text": "Yes"
+            "text": "Yes",
+            "value": true
           },
           {
             "key": "no",
@@ -243,6 +251,13 @@
           }
         ],
         "read_only": "true",
+        "relevance": {
+          "rules-engine": {
+            "ex-rules": {
+              "rules-file": "grad_relevance.yml"
+            }
+          }
+        },
         "calculation": {
           "rules-engine": {
             "ex-rules": {

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/household_referral.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/household_referral.json
@@ -51,14 +51,18 @@
     "display_back_button": "true",
     "fields": [
       {
-        "key": "unique_id",
+        "key": "household_id",
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "unique_id",
+        "openmrs_entity_id": "household_id",
         "type": "edit_text",
-        "hint": "VCA ID",
+        "read_only": "true",
+        "hint": "Household ID",
         "edit_type": "name",
-        "read_only": "true"
+        "v_required": {
+          "value": true,
+          "err": "Household ID is Required"
+        }
       },
       {
         "key": "caseworker_name",

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_caregiver.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_caregiver.json
@@ -1080,39 +1080,7 @@
           }
         }
       },
-      {
-        "key": "case_worker",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "case_worker",
-        "type": "edit_text",
-        "hint": "Name of Case Worker Conducting Assessment",
-        "edit_type": "name",
-        "read_only": "false",
-        "look_up": "true",
-        "v_regex": {
-          "value": "[A-Za-z\\s\\.\\-]*",
-          "err": "Please enter a valid name"
-        }
-      },
-      {
-        "key": "caseworker_date_signed",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "caseworker_date_signed",
-        "type": "date_picker",
-        "hint": "Date Case Worker Signs",
-        "expanded": false,
-        "duration": {
-          "label": ""
-        },
-        "min_date": "today-100y",
-        "max_date": "today",
-        "v_required": {
-          "value": false,
-          "err": "Date Signed"
-        }
-      },
+
 
       {
         "key": "case_manager",
@@ -1127,25 +1095,6 @@
         "v_regex": {
           "value": "[A-Za-z\\s\\.\\-]*",
           "err": "Please enter a valid name"
-        }
-      },
-
-      {
-        "key": "manager_date_signed",
-        "openmrs_entity_parent": "",
-        "openmrs_entity": "person_attribute",
-        "openmrs_entity_id": "manager_date_signed",
-        "type": "date_picker",
-        "hint": "Verified by Case ManagerSigns",
-        "expanded": false,
-        "duration": {
-          "label": ""
-        },
-        "min_date": "today-100y",
-        "max_date": "today",
-        "v_required": {
-          "value": false,
-          "err": "Date Signed"
         }
       },
       {
@@ -1163,8 +1112,6 @@
           "err": "Please enter a valid name"
         }
       },
-
-
       {
         "key": "telephone",
         "openmrs_entity_parent": "",

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_vca_0_20_years.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/household_visitation_for_vca_0_20_years.json
@@ -2028,7 +2028,7 @@
         "type": "edit_text",
         "hint": "Days missed as reported by OVC/Caregiver",
         "edit_type": "number",
-        "read_only": "true",
+        "read_only": "false",
         "look_up": "true",
         "relevance": {
           "step1:currently_in_school": {

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_household.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_household.json
@@ -202,10 +202,6 @@
             "text": "Family received material support"
           },
           {
-            "key": "Child or caregiver referred to health legal or other services",
-            "text": "Child or caregiver referred to health, legal or other services"
-          },
-          {
             "key": "other",
             "text": "Other: Specify"
           }

--- a/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_vca.json
+++ b/opensrp-ecap-chw/src/ecap/assets/json.form/service_report_vca.json
@@ -200,7 +200,7 @@
         "openmrs_entity_parent": "",
         "openmrs_entity": "person_attribute",
         "openmrs_entity_id": "services",
-        "label": "Type of Caregiver Service(s)",
+        "label": "Type of VCA Service (s)",
         "label_info_text": "Tick (x) Services Provided for Caregivers",
         "type": "check_box",
         "options": [

--- a/opensrp-ecap-chw/src/ecap/assets/rule/grad_calculation.yml
+++ b/opensrp-ecap-chw/src/ecap/assets/rule/grad_calculation.yml
@@ -9,7 +9,7 @@ actions:
 name: step1_virally_suppressed
 description: virally_suppressed
 priority: 1
-condition: "step1_vl_last_result < 1000 && step1_date_calculated < 13"
+condition: "(step1_vl_last_result < 1000 && step1_date_calculated < 13) && step1_is_hiv_positive.contains('yes')"
 actions:
   - "calculation = 'yes'"
 ---
@@ -40,3 +40,10 @@ priority: 2
 condition: "!(step2_prevention_correct > 1 && step2_protect_correct > 1 && step2_infection_correct > 1)"
 actions:
   - "calculation = 0"
+---
+name: step2_correct
+description: step2_correct
+priority: 1
+condition: "step1_prevention_correct "
+actions:
+  - "calculation = 1"

--- a/opensrp-ecap-chw/src/ecap/assets/rule/grad_relevance.yml
+++ b/opensrp-ecap-chw/src/ecap/assets/rule/grad_relevance.yml
@@ -75,3 +75,10 @@ priority: 1
 condition: "step1_age < 6"
 actions:
   - "isRelevant = true"
+---
+name: step1_virally_suppressed
+description: Virally
+priority: 1
+condition: "(step1_vl_last_result < 1000 && step1_date_calculated < 13) && step1_is_hiv_positive.contains('yes')"
+actions:
+  - "isRelevant = true"

--- a/opensrp-ecap-chw/src/ecap/assets/rule/household_visitation_form_0_20.yml
+++ b/opensrp-ecap-chw/src/ecap/assets/rule/household_visitation_form_0_20.yml
@@ -149,7 +149,7 @@ actions:
 name: step1_muac_measurement_b
 description: muac_measurement_b
 priority: 1
-condition: "step1_age > 5"
+condition: "step1_age <= 5"
 actions:
   - "isRelevant = true"
 ---
@@ -184,7 +184,7 @@ actions:
 name: step1_nutrition_status
 description: nutrition_status
 priority: 1
-condition: "step1_age > 5"
+condition: "step1_age <= 5"
 actions:
   - "isRelevant = true"
 ---

--- a/opensrp-ecap-chw/src/ecap/java/com/bluecodeltd/ecap/chw/activity/ShowHouseholdReferralsActivity.java
+++ b/opensrp-ecap-chw/src/ecap/java/com/bluecodeltd/ecap/chw/activity/ShowHouseholdReferralsActivity.java
@@ -1,0 +1,270 @@
+package com.bluecodeltd.ecap.chw.activity;
+
+import static org.smartregister.opd.utils.OpdJsonFormUtils.tagSyncMetadata;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.DefaultItemAnimator;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bluecodeltd.ecap.chw.BuildConfig;
+import com.bluecodeltd.ecap.chw.R;
+import com.bluecodeltd.ecap.chw.adapter.ShowHouseholdReferralsAdapter;
+import com.bluecodeltd.ecap.chw.application.ChwApplication;
+import com.bluecodeltd.ecap.chw.dao.ReferralDao;
+import com.bluecodeltd.ecap.chw.domain.ChildIndexEventClient;
+import com.bluecodeltd.ecap.chw.model.ReferralModel;
+import com.bluecodeltd.ecap.chw.util.Constants;
+import com.vijay.jsonwizard.constants.JsonFormConstants;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.smartregister.chw.core.custom_views.NavigationMenu;
+import org.smartregister.client.utils.domain.Form;
+import org.smartregister.clientandeventmodel.Client;
+import org.smartregister.clientandeventmodel.Event;
+import org.smartregister.domain.db.EventClient;
+import org.smartregister.domain.tag.FormTag;
+import org.smartregister.family.util.AppExecutors;
+import org.smartregister.family.util.JsonFormUtils;
+import org.smartregister.repository.AllSharedPreferences;
+import org.smartregister.sync.ClientProcessorForJava;
+import org.smartregister.sync.helper.ECSyncHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import es.dmoral.toasty.Toasty;
+import timber.log.Timber;
+
+public class ShowHouseholdReferralsActivity extends AppCompatActivity {
+
+    public String household_id, intent_vcaid;
+    RecyclerView.Adapter recyclerViewadapter;
+    private RecyclerView recyclerView;
+    private final ArrayList<ReferralModel> referralList = new ArrayList<>();
+    private LinearLayout linearLayout;
+    private TextView vcaname, hh_id, txtReferral,txtBold;
+    private Toolbar toolbar;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_show_household_referrals);
+        toolbar = findViewById(R.id.toolbarx);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+        NavigationMenu.getInstance(this, null, toolbar);
+
+
+        recyclerView = findViewById(R.id.referralRecyclerView);
+        linearLayout = findViewById(R.id.child_container);
+        vcaname = findViewById(R.id.caregiver_name);
+        hh_id = findViewById(R.id.hhid);
+        txtReferral = findViewById(R.id.txtNoReferral);
+
+        Bundle bundle = getIntent().getExtras();
+        intent_vcaid = bundle.getString("householdId");
+        String intent_cname = bundle.getString("householdName");
+
+        hh_id.setText("Household ID : " + intent_vcaid);
+        vcaname.setText(intent_cname+ " " +"Household");
+        txtReferral.setText("No referrals have been added for " +intent_cname+ " " +"household");
+
+
+        referralList.addAll(ReferralDao.getReferralsByHouseholdID(intent_vcaid));
+        RecyclerView.LayoutManager eLayoutManager = new LinearLayoutManager(ShowHouseholdReferralsActivity.this);
+        recyclerView.setHasFixedSize(true);
+        recyclerView.setLayoutManager(eLayoutManager);
+        recyclerView.setItemAnimator(new DefaultItemAnimator());
+        recyclerViewadapter = new ShowHouseholdReferralsAdapter(referralList, ShowHouseholdReferralsActivity.this);
+        recyclerView.setAdapter(recyclerViewadapter);
+        recyclerViewadapter.notifyDataSetChanged();
+
+        if (recyclerViewadapter.getItemCount() > 0) {
+
+            linearLayout.setVisibility(View.GONE);
+        }
+    }
+
+    public void startFormActivity(JSONObject jsonObject) {
+
+        Form form = new Form();
+        form.setWizard(false);
+        form.setName("Referral Form");
+        form.setHideSaveLabel(true);
+        form.setNextLabel(getString(R.string.next));
+        form.setPreviousLabel(getString(R.string.previous));
+        form.setSaveLabel(getString(R.string.submit));
+        form.setNavigationBackground(R.color.primary);
+        Intent intent = new Intent(this, org.smartregister.family.util.Utils.metadata().familyFormActivity);
+        intent.putExtra(JsonFormConstants.JSON_FORM_KEY.FORM, form);
+        intent.putExtra(JsonFormConstants.JSON_FORM_KEY.JSON, jsonObject.toString());
+        startActivityForResult(intent, JsonFormUtils.REQUEST_CODE_GET_JSON);
+
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == JsonFormUtils.REQUEST_CODE_GET_JSON && resultCode == RESULT_OK) {
+
+            boolean is_edit_mode = false;
+
+            String jsonString = data.getStringExtra(JsonFormConstants.JSON_FORM_KEY.JSON);
+
+            JSONObject jsonFormObject = null;
+            try {
+                jsonFormObject = new JSONObject(jsonString);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+
+
+            try {
+
+                ChildIndexEventClient childIndexEventClient = processRegistration(jsonString);
+
+                if (childIndexEventClient == null) {
+                    return;
+                }
+
+                saveRegistration(childIndexEventClient, false);
+
+                Toasty.success(ShowHouseholdReferralsActivity.this, "Referral Updated", Toast.LENGTH_LONG, true).show();
+
+            } catch (Exception e) {
+                Timber.e(e);
+            }
+        }
+        finish();
+        startActivity(getIntent());
+    }
+
+    public ChildIndexEventClient processRegistration(String jsonString) {
+
+        try {
+            JSONObject formJsonObject = new JSONObject(jsonString);
+
+            String encounterType = formJsonObject.getString(JsonFormConstants.ENCOUNTER_TYPE);
+
+            String entityId = formJsonObject.optString("entity_id");
+
+            if (entityId.isEmpty()) {
+                entityId = org.smartregister.util.JsonFormUtils.generateRandomUUIDString();
+            }
+
+
+            JSONObject metadata = formJsonObject.getJSONObject(Constants.METADATA);
+
+
+            JSONArray fields = org.smartregister.util.JsonFormUtils.fields(formJsonObject);
+
+            switch (encounterType) {
+                case "Referral":
+
+                    if (fields != null) {
+                        FormTag formTag = getFormTag();
+                        Event event = org.smartregister.util.JsonFormUtils.createEvent(fields, metadata, formTag, entityId,
+                                encounterType, Constants.EcapClientTable.EC_REFERRAL);
+                        tagSyncMetadata(event);
+                        Client client = org.smartregister.util.JsonFormUtils.createBaseClient(fields, formTag, entityId);
+                        return new ChildIndexEventClient(event, client);
+                    }
+                    break;
+
+            }
+        } catch (JSONException e) {
+            Timber.e(e);
+        }
+
+        return null;
+    }
+
+    public boolean saveRegistration(ChildIndexEventClient childIndexEventClient, boolean isEditMode) {
+
+        Runnable runnable = () -> {
+
+            Event event = childIndexEventClient.getEvent();
+            Client client = childIndexEventClient.getClient();
+
+            if (event != null && client != null) {
+                try {
+                    ECSyncHelper ecSyncHelper = getECSyncHelper();
+
+                    JSONObject newClientJsonObject = new JSONObject(org.smartregister.util.JsonFormUtils.gson.toJson(client));
+
+                    JSONObject existingClientJsonObject = ecSyncHelper.getClient(client.getBaseEntityId());
+
+                    if (isEditMode) {
+                        JSONObject mergedClientJsonObject =
+                                org.smartregister.util.JsonFormUtils.merge(existingClientJsonObject, newClientJsonObject);
+                        ecSyncHelper.addClient(client.getBaseEntityId(), mergedClientJsonObject);
+                    } else {
+                        ecSyncHelper.addClient(client.getBaseEntityId(), newClientJsonObject);
+                    }
+
+                    JSONObject eventJsonObject = new JSONObject(org.smartregister.util.JsonFormUtils.gson.toJson(event));
+                    ecSyncHelper.addEvent(event.getBaseEntityId(), eventJsonObject);
+
+                    Long lastUpdatedAtDate = getAllSharedPreferences().fetchLastUpdatedAtDate(0);
+                    Date currentSyncDate = new Date(lastUpdatedAtDate);
+
+                    //Get saved event for processing
+                    List<EventClient> savedEvents = ecSyncHelper.getEvents(Collections.singletonList(event.getFormSubmissionId()));
+                    getClientProcessorForJava().processClient(savedEvents);
+                    getAllSharedPreferences().saveLastUpdatedAtDate(currentSyncDate.getTime());
+
+
+                } catch (Exception e) {
+                    Timber.e(e);
+                }
+            }
+
+        };
+
+
+        try {
+            AppExecutors appExecutors = new AppExecutors();
+            appExecutors.diskIO().execute(runnable);
+            return true;
+        } catch (Exception exception) {
+            Timber.e(exception);
+            return false;
+        }
+    }
+
+    private ECSyncHelper getECSyncHelper() {
+        return ChwApplication.getInstance().getEcSyncHelper();
+    }
+
+    public FormTag getFormTag() {
+        FormTag formTag = new FormTag();
+        AllSharedPreferences allSharedPreferences = getAllSharedPreferences();
+        formTag.providerId = allSharedPreferences.fetchRegisteredANM();
+        formTag.appVersion = BuildConfig.VERSION_CODE;
+        formTag.databaseVersion = BuildConfig.DATABASE_VERSION;
+        return formTag;
+    }
+
+    public AllSharedPreferences getAllSharedPreferences() {
+        return ChwApplication.getInstance().getContext().allSharedPreferences();
+    }
+
+    private ClientProcessorForJava getClientProcessorForJava() {
+        return ChwApplication.getInstance().getClientProcessorForJava();
+    }
+}

--- a/opensrp-ecap-chw/src/ecap/res/values/strings.xml
+++ b/opensrp-ecap-chw/src/ecap/res/values/strings.xml
@@ -30,7 +30,7 @@
     <string name="all_households"> Household Register</string>
     <string name="all_Vcas"> VCAs</string>
     <string name="all_benefeciaries"> Case Plans</string>
-    <string name="facility_ovc_register" translatable="false"> VCA Index Register</string>
+    <string name="facility_ovc_register" translatable="false"> VCA Register</string>
     <string name="mother_index_register">Mother Index Register</string>
     <string name="household_index_register">Household Register</string>
     <string name="all_indexes"> Indexes</string>

--- a/opensrp-ecap-chw/src/main/AndroidManifest.xml
+++ b/opensrp-ecap-chw/src/main/AndroidManifest.xml
@@ -37,24 +37,21 @@
         android:theme="@style/ChwTheme"
         android:usesCleartextTraffic="true"
         tools:replace="android:theme">
-
-        <activity
-            android:name=".activity.ShowReferralsActivity"
-            android:theme="@style/ChwTheme.NoActionBar" />
         <activity
             android:name=".activity.ShowHouseholdReferralsActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
         <activity
+            android:name=".activity.ShowReferralsActivity"
+            android:theme="@style/ChwTheme.NoActionBar" />
+        <activity
             android:name=".activity.VcaServiceActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
-
         <activity
             android:name=".activity.ChildSafetyPlanActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
         <activity
             android:name=".activity.ChildSafetyPlanActions"
             android:theme="@style/ChwTheme.NoActionBar" />
-
         <activity
             android:name=".activity.HouseholdServiceActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
@@ -66,12 +63,11 @@
             android:name=".activity.HouseholdCasePlanActivity"
             android:exported="true"
             android:label="Caregiver Case Plan" />
-
         <activity
             android:name=".activity.DashboardActivity"
             android:exported="true"
-            android:theme="@style/ChwTheme.NoActionBar"
-            android:label="Reports" />
+            android:label="Reports"
+            android:theme="@style/ChwTheme.NoActionBar" />
         <activity
             android:name=".activity.Profile"
             android:exported="true" />

--- a/opensrp-ecap-chw/src/main/AndroidManifest.xml
+++ b/opensrp-ecap-chw/src/main/AndroidManifest.xml
@@ -42,6 +42,9 @@
             android:name=".activity.ShowReferralsActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
         <activity
+            android:name=".activity.ShowHouseholdReferralsActivity"
+            android:theme="@style/ChwTheme.NoActionBar" />
+        <activity
             android:name=".activity.VcaServiceActivity"
             android:theme="@style/ChwTheme.NoActionBar" />
 

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/HouseholdDetails.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/HouseholdDetails.java
@@ -2,7 +2,6 @@ package com.bluecodeltd.ecap.chw.activity;
 
 import static com.vijay.jsonwizard.utils.FormUtils.fields;
 import static com.vijay.jsonwizard.utils.FormUtils.getFieldJSONObject;
-import static com.vijay.jsonwizard.utils.FormUtils.getJSONObject;
 import static org.smartregister.family.util.JsonFormUtils.STEP2;
 import static org.smartregister.opd.utils.OpdJsonFormUtils.tagSyncMetadata;
 import static org.smartregister.util.JsonFormUtils.STEP1;
@@ -43,7 +42,6 @@ import com.bluecodeltd.ecap.chw.dao.GradDao;
 import com.bluecodeltd.ecap.chw.dao.GraduationDao;
 import com.bluecodeltd.ecap.chw.dao.HouseholdDao;
 import com.bluecodeltd.ecap.chw.dao.IndexPersonDao;
-import com.bluecodeltd.ecap.chw.dao.VcaVisitationDao;
 import com.bluecodeltd.ecap.chw.dao.WeServiceCaregiverDoa;
 import com.bluecodeltd.ecap.chw.domain.ChildIndexEventClient;
 import com.bluecodeltd.ecap.chw.fragment.HouseholdCasePlanFragment;
@@ -52,13 +50,13 @@ import com.bluecodeltd.ecap.chw.fragment.HouseholdOverviewFragment;
 import com.bluecodeltd.ecap.chw.fragment.HouseholdVisitsFragment;
 import com.bluecodeltd.ecap.chw.model.Caregiver;
 import com.bluecodeltd.ecap.chw.model.CaregiverAssessmentModel;
-import com.bluecodeltd.ecap.chw.model.Child;
-import com.bluecodeltd.ecap.chw.model.GraduationModel;
-import com.bluecodeltd.ecap.chw.model.WeServiceCaregiverModel;
 import com.bluecodeltd.ecap.chw.model.CaregiverHivAssessmentModel;
 import com.bluecodeltd.ecap.chw.model.CaregiverHouseholdvisitationModel;
 import com.bluecodeltd.ecap.chw.model.CaregiverVisitationModel;
+import com.bluecodeltd.ecap.chw.model.Child;
+import com.bluecodeltd.ecap.chw.model.GraduationModel;
 import com.bluecodeltd.ecap.chw.model.Household;
+import com.bluecodeltd.ecap.chw.model.WeServiceCaregiverModel;
 import com.bluecodeltd.ecap.chw.util.Constants;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.android.material.floatingactionbutton.FloatingActionButton;
@@ -428,6 +426,16 @@ public class HouseholdDetails extends AppCompatActivity {
                 startActivity(intent);
 
                 break;
+            case R.id.householdReferrals:
+
+                Intent showReferrals = new Intent(HouseholdDetails.this, ShowHouseholdReferralsActivity.class);
+                Bundle referral = new Bundle();
+                referral.putString("householdId",house.getHousehold_id());
+                referral.putString("householdName",house.getCaregiver_name());
+                showReferrals.putExtras(referral);
+
+                startActivity(showReferrals);
+                break;
 
             case R.id.fabx:
 
@@ -522,7 +530,7 @@ public class HouseholdDetails extends AppCompatActivity {
             case R.id.h_referral:
                 try {
 
-                    indexRegisterForm = formUtils.getFormJson("referral");
+                    indexRegisterForm = formUtils.getFormJson("household_referral");
 
                     //TODO
                     // CoreJsonFormUtils.populateJsonForm(indexRegisterForm, client.getColumnmaps());

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/ShowHouseholdReferralActivity.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/activity/ShowHouseholdReferralActivity.java
@@ -1,0 +1,270 @@
+package com.bluecodeltd.ecap.chw.activity;
+
+import static org.smartregister.opd.utils.OpdJsonFormUtils.tagSyncMetadata;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.view.View;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+import android.widget.Toast;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
+import androidx.recyclerview.widget.DefaultItemAnimator;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bluecodeltd.ecap.chw.BuildConfig;
+import com.bluecodeltd.ecap.chw.R;
+import com.bluecodeltd.ecap.chw.adapter.ShowHouseholdReferralsAdapter;
+import com.bluecodeltd.ecap.chw.application.ChwApplication;
+import com.bluecodeltd.ecap.chw.dao.ReferralDao;
+import com.bluecodeltd.ecap.chw.domain.ChildIndexEventClient;
+import com.bluecodeltd.ecap.chw.model.ReferralModel;
+import com.bluecodeltd.ecap.chw.util.Constants;
+import com.vijay.jsonwizard.constants.JsonFormConstants;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.smartregister.chw.core.custom_views.NavigationMenu;
+import org.smartregister.client.utils.domain.Form;
+import org.smartregister.clientandeventmodel.Client;
+import org.smartregister.clientandeventmodel.Event;
+import org.smartregister.domain.db.EventClient;
+import org.smartregister.domain.tag.FormTag;
+import org.smartregister.family.util.AppExecutors;
+import org.smartregister.family.util.JsonFormUtils;
+import org.smartregister.repository.AllSharedPreferences;
+import org.smartregister.sync.ClientProcessorForJava;
+import org.smartregister.sync.helper.ECSyncHelper;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import es.dmoral.toasty.Toasty;
+import timber.log.Timber;
+
+public class ShowHouseholdReferralActivity extends AppCompatActivity {
+
+    public String household_id, intent_vcaid;
+    RecyclerView.Adapter recyclerViewadapter;
+    private RecyclerView recyclerView;
+    private final ArrayList<ReferralModel> referralList = new ArrayList<>();
+    private LinearLayout linearLayout;
+    private TextView vcaname, hh_id, txtReferral,txtBold;
+    private Toolbar toolbar;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_show_household_referrals);
+        toolbar = findViewById(R.id.toolbarx);
+        setSupportActionBar(toolbar);
+        getSupportActionBar().setDisplayShowTitleEnabled(false);
+        NavigationMenu.getInstance(this, null, toolbar);
+
+
+        recyclerView = findViewById(R.id.referralRecyclerView);
+        linearLayout = findViewById(R.id.child_container);
+        vcaname = findViewById(R.id.caregiver_name);
+        hh_id = findViewById(R.id.hhid);
+        txtReferral = findViewById(R.id.txtNoReferral);
+
+        Bundle bundle = getIntent().getExtras();
+        intent_vcaid = bundle.getString("householdId");
+        String intent_cname = bundle.getString("householdName");
+
+        hh_id.setText("Household ID : " + intent_vcaid);
+        vcaname.setText(intent_cname+ " " +"Household");
+        txtReferral.setText("No referrals have been added for " +intent_cname+ " " +"household");
+
+
+        referralList.addAll(ReferralDao.getReferralsByHouseholdID(intent_vcaid));
+        RecyclerView.LayoutManager eLayoutManager = new LinearLayoutManager(ShowHouseholdReferralActivity.this);
+        recyclerView.setHasFixedSize(true);
+        recyclerView.setLayoutManager(eLayoutManager);
+        recyclerView.setItemAnimator(new DefaultItemAnimator());
+        recyclerViewadapter = new ShowHouseholdReferralsAdapter(referralList, ShowHouseholdReferralActivity.this);
+        recyclerView.setAdapter(recyclerViewadapter);
+        recyclerViewadapter.notifyDataSetChanged();
+
+        if (recyclerViewadapter.getItemCount() > 0) {
+
+            linearLayout.setVisibility(View.GONE);
+        }
+    }
+
+    public void startFormActivity(JSONObject jsonObject) {
+
+        Form form = new Form();
+        form.setWizard(false);
+        form.setName("Referral Form");
+        form.setHideSaveLabel(true);
+        form.setNextLabel(getString(R.string.next));
+        form.setPreviousLabel(getString(R.string.previous));
+        form.setSaveLabel(getString(R.string.submit));
+        form.setNavigationBackground(R.color.primary);
+        Intent intent = new Intent(this, org.smartregister.family.util.Utils.metadata().familyFormActivity);
+        intent.putExtra(JsonFormConstants.JSON_FORM_KEY.FORM, form);
+        intent.putExtra(JsonFormConstants.JSON_FORM_KEY.JSON, jsonObject.toString());
+        startActivityForResult(intent, JsonFormUtils.REQUEST_CODE_GET_JSON);
+
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (requestCode == JsonFormUtils.REQUEST_CODE_GET_JSON && resultCode == RESULT_OK) {
+
+            boolean is_edit_mode = false;
+
+            String jsonString = data.getStringExtra(JsonFormConstants.JSON_FORM_KEY.JSON);
+
+            JSONObject jsonFormObject = null;
+            try {
+                jsonFormObject = new JSONObject(jsonString);
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+
+
+            try {
+
+                ChildIndexEventClient childIndexEventClient = processRegistration(jsonString);
+
+                if (childIndexEventClient == null) {
+                    return;
+                }
+
+                saveRegistration(childIndexEventClient, false);
+
+                Toasty.success(ShowHouseholdReferralActivity.this, "Referral Updated", Toast.LENGTH_LONG, true).show();
+
+            } catch (Exception e) {
+                Timber.e(e);
+            }
+        }
+        finish();
+        startActivity(getIntent());
+    }
+
+    public ChildIndexEventClient processRegistration(String jsonString) {
+
+        try {
+            JSONObject formJsonObject = new JSONObject(jsonString);
+
+            String encounterType = formJsonObject.getString(JsonFormConstants.ENCOUNTER_TYPE);
+
+            String entityId = formJsonObject.optString("entity_id");
+
+            if (entityId.isEmpty()) {
+                entityId = org.smartregister.util.JsonFormUtils.generateRandomUUIDString();
+            }
+
+
+            JSONObject metadata = formJsonObject.getJSONObject(Constants.METADATA);
+
+
+            JSONArray fields = org.smartregister.util.JsonFormUtils.fields(formJsonObject);
+
+            switch (encounterType) {
+                case "Referral":
+
+                    if (fields != null) {
+                        FormTag formTag = getFormTag();
+                        Event event = org.smartregister.util.JsonFormUtils.createEvent(fields, metadata, formTag, entityId,
+                                encounterType, Constants.EcapClientTable.EC_REFERRAL);
+                        tagSyncMetadata(event);
+                        Client client = org.smartregister.util.JsonFormUtils.createBaseClient(fields, formTag, entityId);
+                        return new ChildIndexEventClient(event, client);
+                    }
+                    break;
+
+            }
+        } catch (JSONException e) {
+            Timber.e(e);
+        }
+
+        return null;
+    }
+
+    public boolean saveRegistration(ChildIndexEventClient childIndexEventClient, boolean isEditMode) {
+
+        Runnable runnable = () -> {
+
+            Event event = childIndexEventClient.getEvent();
+            Client client = childIndexEventClient.getClient();
+
+            if (event != null && client != null) {
+                try {
+                    ECSyncHelper ecSyncHelper = getECSyncHelper();
+
+                    JSONObject newClientJsonObject = new JSONObject(org.smartregister.util.JsonFormUtils.gson.toJson(client));
+
+                    JSONObject existingClientJsonObject = ecSyncHelper.getClient(client.getBaseEntityId());
+
+                    if (isEditMode) {
+                        JSONObject mergedClientJsonObject =
+                                org.smartregister.util.JsonFormUtils.merge(existingClientJsonObject, newClientJsonObject);
+                        ecSyncHelper.addClient(client.getBaseEntityId(), mergedClientJsonObject);
+                    } else {
+                        ecSyncHelper.addClient(client.getBaseEntityId(), newClientJsonObject);
+                    }
+
+                    JSONObject eventJsonObject = new JSONObject(org.smartregister.util.JsonFormUtils.gson.toJson(event));
+                    ecSyncHelper.addEvent(event.getBaseEntityId(), eventJsonObject);
+
+                    Long lastUpdatedAtDate = getAllSharedPreferences().fetchLastUpdatedAtDate(0);
+                    Date currentSyncDate = new Date(lastUpdatedAtDate);
+
+                    //Get saved event for processing
+                    List<EventClient> savedEvents = ecSyncHelper.getEvents(Collections.singletonList(event.getFormSubmissionId()));
+                    getClientProcessorForJava().processClient(savedEvents);
+                    getAllSharedPreferences().saveLastUpdatedAtDate(currentSyncDate.getTime());
+
+
+                } catch (Exception e) {
+                    Timber.e(e);
+                }
+            }
+
+        };
+
+
+        try {
+            AppExecutors appExecutors = new AppExecutors();
+            appExecutors.diskIO().execute(runnable);
+            return true;
+        } catch (Exception exception) {
+            Timber.e(exception);
+            return false;
+        }
+    }
+
+    private ECSyncHelper getECSyncHelper() {
+        return ChwApplication.getInstance().getEcSyncHelper();
+    }
+
+    public FormTag getFormTag() {
+        FormTag formTag = new FormTag();
+        AllSharedPreferences allSharedPreferences = getAllSharedPreferences();
+        formTag.providerId = allSharedPreferences.fetchRegisteredANM();
+        formTag.appVersion = BuildConfig.VERSION_CODE;
+        formTag.databaseVersion = BuildConfig.DATABASE_VERSION;
+        return formTag;
+    }
+
+    public AllSharedPreferences getAllSharedPreferences() {
+        return ChwApplication.getInstance().getContext().allSharedPreferences();
+    }
+
+    private ClientProcessorForJava getClientProcessorForJava() {
+        return ChwApplication.getInstance().getClientProcessorForJava();
+    }
+}

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ChildrenAdapter.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ChildrenAdapter.java
@@ -111,7 +111,7 @@ public class ChildrenAdapter extends RecyclerView.Adapter<ChildrenAdapter.ViewHo
             holder.gradBtn.setColorFilter(ContextCompat.getColor(context, R.color.dark_grey));
 
         } else {
-            holder.gradBtn.setBackground(ContextCompat.getDrawable(context, R.drawable.grad_bg2));
+//            holder.gradBtn.setBackground(ContextCompat.getDrawable(context, R.drawable.grad_bg2));
             holder.gradBtn.setColorFilter(ContextCompat.getColor(context, R.color.colorGreen));
 
         }

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ShowHouseholdReferralsAdapter.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ShowHouseholdReferralsAdapter.java
@@ -60,7 +60,7 @@ public class ShowHouseholdReferralsAdapter extends RecyclerView.Adapter<ShowHous
 
         holder.setIsRecyclable(false);
 
-        holder.txtDate.setText(showReferrals.getDate_referred());
+        holder.txtDate.setText(showReferrals.getReferred_date());
 
         holder.linearLayout.setOnClickListener(v -> {
 

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ShowHouseholdReferralsAdapter.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ShowHouseholdReferralsAdapter.java
@@ -1,0 +1,166 @@
+package com.bluecodeltd.ecap.chw.adapter;
+
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.bluecodeltd.ecap.chw.R;
+import com.bluecodeltd.ecap.chw.model.ReferralModel;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.vijay.jsonwizard.constants.JsonFormConstants;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.smartregister.chw.core.utils.CoreJsonFormUtils;
+import org.smartregister.client.utils.domain.Form;
+import org.smartregister.family.util.JsonFormUtils;
+import org.smartregister.util.FormUtils;
+
+import java.util.List;
+import java.util.Map;
+
+public class ShowHouseholdReferralsAdapter extends RecyclerView.Adapter<ShowHouseholdReferralsAdapter.ViewHolder> {
+
+    Context context;
+
+    List<ReferralModel> referrals;
+    ObjectMapper oMapper;
+
+    public ShowHouseholdReferralsAdapter(List<ReferralModel> referrals, Context context){
+
+        super();
+
+        this.referrals = referrals;
+        this.context = context;
+    }
+
+    @Override
+    public ShowHouseholdReferralsAdapter.ViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+
+
+        View v = LayoutInflater.from(parent.getContext()).inflate(R.layout.single_referral, parent, false);
+
+        ShowHouseholdReferralsAdapter.ViewHolder viewHolder = new ShowHouseholdReferralsAdapter.ViewHolder(v);
+
+        return viewHolder;
+    }
+
+    @Override
+    public void onBindViewHolder(ShowHouseholdReferralsAdapter.ViewHolder holder, final int position) {
+
+        final ReferralModel showReferrals = referrals.get(position);
+
+        holder.setIsRecyclable(false);
+
+        holder.txtDate.setText(showReferrals.getDate_referred());
+
+        holder.linearLayout.setOnClickListener(v -> {
+
+            if (v.getId() == R.id.itemm) {
+
+                try {
+
+                    openFormUsingFormUtils(context, "household_referral", showReferrals);
+
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                }
+
+            }
+        });
+        holder.editme.setOnClickListener(v -> {
+
+            if (v.getId() == R.id.edit_me) {
+
+                try {
+
+                    openFormUsingFormUtils(context, "household_referral", showReferrals);
+
+
+                } catch (JSONException e) {
+                    e.printStackTrace();
+                }
+
+            }
+        });
+
+    }
+
+    public void openFormUsingFormUtils(Context context, String formName, ReferralModel referral) throws JSONException {
+
+        oMapper = new ObjectMapper();
+
+        FormUtils formUtils = null;
+        try {
+            formUtils = new FormUtils(context);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        JSONObject formToBeOpened;
+
+        formToBeOpened = formUtils.getFormJson(formName);
+
+        formToBeOpened.put("entity_id", referral.getBase_entity_id());
+
+        CoreJsonFormUtils.populateJsonForm(formToBeOpened, oMapper.convertValue(referral, Map.class));
+
+        startFormActivity(formToBeOpened);
+
+    }
+
+    public void startFormActivity(JSONObject jsonObject) {
+
+        Form form = new Form();
+        form.setWizard(false);
+        form.setName("Follow Up Visitation");
+        form.setHideSaveLabel(true);
+        form.setNextLabel("Next");
+        form.setPreviousLabel("Previous");
+        form.setSaveLabel("Submit");
+        form.setActionBarBackground(R.color.dark_grey);
+        Intent intent = new Intent(context, org.smartregister.family.util.Utils.metadata().familyFormActivity);
+        intent.putExtra(JsonFormConstants.JSON_FORM_KEY.FORM, form);
+        intent.putExtra(JsonFormConstants.JSON_FORM_KEY.JSON, jsonObject.toString());
+        ((Activity) context).startActivityForResult(intent, JsonFormUtils.REQUEST_CODE_GET_JSON);
+
+    }
+
+    @Override
+    public int getItemCount() {
+
+        return referrals.size();
+    }
+
+    class ViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
+
+        TextView txtDate;
+
+        LinearLayout linearLayout;
+        ImageView editme;
+
+        public ViewHolder(View itemView) {
+
+            super(itemView);
+
+            linearLayout = itemView.findViewById(R.id.itemm);
+            txtDate  = itemView.findViewById(R.id.date);
+            editme = itemView.findViewById(R.id.edit_me);
+
+        }
+
+
+        @Override
+        public void onClick(View v) {
+
+        }
+    }
+
+}

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ShowReferralsAdapter.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/adapter/ShowReferralsAdapter.java
@@ -60,7 +60,7 @@ public class ShowReferralsAdapter extends RecyclerView.Adapter<ShowReferralsAdap
 
         holder.setIsRecyclable(false);
 
-        holder.txtDate.setText(showReferrals.getDate_referred());
+        holder.txtDate.setText(showReferrals.getReferred_date());
 
         holder.linearLayout.setOnClickListener(v -> {
 

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/IndexPersonDao.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/IndexPersonDao.java
@@ -3,7 +3,6 @@ package com.bluecodeltd.ecap.chw.dao;
 
 import com.bluecodeltd.ecap.chw.model.CasePlanModel;
 import com.bluecodeltd.ecap.chw.model.Child;
-import com.bluecodeltd.ecap.chw.model.FamilyServiceModel;
 import com.bluecodeltd.ecap.chw.model.VCAServiceModel;
 
 import org.smartregister.dao.AbstractDao;
@@ -449,7 +448,9 @@ public class IndexPersonDao  extends AbstractDao {
                     getCursorValue(c, "vl_next_result"),
                     getCursorValue(c, "physical_address"),
                     getCursorValue(c, "date_offered_enrollment"),
-                    getCursorValue(c, "school_name")
+//                    getCursorValue(c, "school_name"),
+                    getCursorValue(c, "schoolName")
+
 
             );
         };

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/ReferralDao.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/ReferralDao.java
@@ -52,7 +52,7 @@ public class ReferralDao extends AbstractDao {
             ReferralModel record = new ReferralModel();
             record.setBase_entity_id(getCursorValue(c, "base_entity_id"));
             record.setUnique_id(getCursorValue(c,"unique_id"));
-            record.setDate_referred(getCursorValue(c, "date_referred"));
+            record.setReferred_date(getCursorValue(c, "referred_date"));
             record.setReceiving_organization(getCursorValue(c, "receiving_organization"));
             record.setCd4(getCursorValue(c, "cd4"));
             record.setHiv_adherence(getCursorValue(c, "hiv_adherence"));

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/ReferralDao.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/dao/ReferralDao.java
@@ -33,6 +33,19 @@ public class ReferralDao extends AbstractDao {
 
     }
 
+    public static List<ReferralModel> getReferralsByHouseholdID(String hh_ID) {
+
+        String sql = "SELECT * FROM ec_referral WHERE household_id = '" + hh_ID + "' ORDER BY date_referred DESC ";
+
+        List<ReferralModel> values = AbstractDao.readData(sql, getReferralModelMap());
+        if (values == null || values.size() == 0)
+            return new ArrayList<>();
+
+        return values;
+
+    }
+
+
     public static DataMap<ReferralModel> getReferralModelMap() {
         return c -> {
 
@@ -129,6 +142,8 @@ public class ReferralDao extends AbstractDao {
             record.setSpecify_safety(getCursorValue(c, "specify_safety"));
             record.setSpecify_school(getCursorValue(c, "specify_school"));
             record.setSpecify_stability(getCursorValue(c, "specify_stability"));
+            record.setHousehold_id(getCursorValue(c, "household_id"));
+
 
 
             return record;

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/Child.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/Child.java
@@ -502,7 +502,7 @@ public class Child implements Serializable {
         this.schoolName = schoolName;
     }
 
-    @SerializedName("school_name")
+    @SerializedName("schoolName")
     @Expose
     private String schoolName;
 
@@ -529,6 +529,7 @@ public class Child implements Serializable {
     @SerializedName("other_school")
     @Expose
     private String other_school;
+
 
     public String getVl_next_result() {
         return vl_next_result;

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/ReferralModel.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/ReferralModel.java
@@ -96,6 +96,8 @@ public class ReferralModel {
     private String specify_school;
     private String specify_stability;
     private String unique_id;
+    private String household_id;
+
 
 
     public String getBase_entity_id() {
@@ -840,5 +842,13 @@ public class ReferralModel {
 
     public void setSpecify_stability(String specify_stability) {
         this.specify_stability = specify_stability;
+    }
+
+    public String getHousehold_id() {
+        return household_id;
+    }
+
+    public void setHousehold_id(String household_id) {
+        this.household_id = household_id;
     }
 }

--- a/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/ReferralModel.java
+++ b/opensrp-ecap-chw/src/main/java/com/bluecodeltd/ecap/chw/model/ReferralModel.java
@@ -3,7 +3,7 @@ package com.bluecodeltd.ecap.chw.model;
 public class ReferralModel {
 
     private String base_entity_id;
-    private String date_referred;
+    private String referred_date;
     private String receiving_organization;
     private String cd4;
     private String hiv_adherence;
@@ -99,7 +99,6 @@ public class ReferralModel {
     private String household_id;
 
 
-
     public String getBase_entity_id() {
         return base_entity_id;
     }
@@ -108,20 +107,12 @@ public class ReferralModel {
         this.base_entity_id = base_entity_id;
     }
 
-    public String getUnique_id() {
-        return unique_id;
+    public String getReferred_date() {
+        return referred_date;
     }
 
-    public void setUnique_id(String unique_id) {
-        this.unique_id = unique_id;
-    }
-
-    public String getDate_referred() {
-        return date_referred;
-    }
-
-    public void setDate_referred(String date_referred) {
-        this.date_referred = date_referred;
+    public void setReferred_date(String referred_date) {
+        this.referred_date = referred_date;
     }
 
     public String getReceiving_organization() {
@@ -842,6 +833,14 @@ public class ReferralModel {
 
     public void setSpecify_stability(String specify_stability) {
         this.specify_stability = specify_stability;
+    }
+
+    public String getUnique_id() {
+        return unique_id;
+    }
+
+    public void setUnique_id(String unique_id) {
+        this.unique_id = unique_id;
     }
 
     public String getHousehold_id() {

--- a/opensrp-ecap-chw/src/main/res/layout/activity_household_details.xml
+++ b/opensrp-ecap-chw/src/main/res/layout/activity_household_details.xml
@@ -97,21 +97,48 @@
                         </LinearLayout>
 
                     </LinearLayout>
-
-                    <Button
-                        android:onClick="onClick"
-                        android:id="@+id/myservice"
+                    <LinearLayout
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginBottom="15dp"
-                        android:background="@drawable/transparent_white_button"
-                        android:paddingStart="@dimen/profile_btn_registration_info_padding"
-                        android:paddingTop="0dp"
-                        android:paddingEnd="@dimen/profile_btn_registration_info_padding"
-                        android:paddingBottom="0dp"
-                        android:text="Service Reports"
-                        android:textAllCaps="false"
-                        tools:text="Service Reports" />
+                        android:orientation="horizontal">
+
+                        <Button
+                            android:onClick="onClick"
+                            android:id="@+id/myservice"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="15dp"
+                            android:background="@drawable/transparent_white_button"
+                            android:paddingStart="@dimen/profile_btn_registration_info_padding"
+                            android:paddingTop="0dp"
+                            android:paddingEnd="@dimen/profile_btn_registration_info_padding"
+                            android:paddingBottom="0dp"
+                            android:text="Service Reports"
+                            android:textAllCaps="false"
+                            tools:text="Service Reports" />
+                        <Button
+                            android:onClick="onClick"
+                            android:id="@+id/householdReferrals"
+                            android:layout_width="150dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginBottom="15dp"
+                            android:background="@drawable/transparent_white_button"
+                            android:paddingStart="@dimen/profile_btn_registration_info_padding"
+                            android:paddingTop="0dp"
+                            android:paddingEnd="@dimen/profile_btn_registration_info_padding"
+                            android:paddingBottom="0dp"
+                            android:layout_marginLeft="10dp"
+                            android:text="Referrals"
+                            android:textAllCaps="false"
+                            tools:text="Referrals" />
+
+
+
+
+                    </LinearLayout>
+
+
+
 
                 </LinearLayout>
 
@@ -444,7 +471,7 @@
                     app:srcCompat="@android:drawable/ic_input_add" />
 
             </RelativeLayout>
-z
+            z
             <RelativeLayout
                 android:id="@+id/graduation"
                 android:onClick="onClick"

--- a/opensrp-ecap-chw/src/main/res/layout/activity_show_household_referrals.xml
+++ b/opensrp-ecap-chw/src/main/res/layout/activity_show_household_referrals.xml
@@ -1,0 +1,149 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.coordinatorlayout.widget.CoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    tools:context=".activity.ShowReferralsActivity"
+    android:layout_height="match_parent"
+    android:background="@android:color/white">
+
+    <RelativeLayout
+        android:id="@+id/activity_main"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <com.google.android.material.appbar.AppBarLayout
+            android:id="@+id/collapsing_toolbar_appbarlayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="#36454F">
+
+            <com.google.android.material.appbar.CollapsingToolbarLayout
+                android:id="@+id/collapsing_toolbar_layout"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:theme="@style/ThemeOverlay.AppCompat.Dark.ActionBar"
+                app:contentScrim="@color/customAppThemeBlue"
+                app:layout_scrollFlags="scroll|exitUntilCollapsed">
+
+                <androidx.appcompat.widget.Toolbar
+                    android:id="@+id/toolbarx"
+                    android:layout_width="match_parent"
+                    android:layout_height="56dp"
+                    android:background="#36454F"
+                    app:theme="@style/ThemeOverlay.AppCompat.Light"
+                    app:layout_collapseMode="pin" />
+
+                <LinearLayout
+                    android:layout_marginTop="56dp"
+                    android:id="@+id/profile_name_layout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="#36454F"
+                    android:gravity="center_horizontal"
+                    android:orientation="vertical"
+                    app:layout_collapseMode="parallax"
+                    app:layout_collapseParallaxMultiplier="1.5">
+
+
+                    <org.smartregister.view.customcontrols.CustomFontTextView
+                        android:id="@+id/caregiver_name"
+                        style="@style/CustomFontTextViewStyle.ClientList.Medium"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginTop="15dp"
+                        android:paddingStart="0dp"
+                        android:text="VCA : Bertha Mwansa"
+                        android:textColor="@android:color/white"
+                        android:textSize="@dimen/activity_title_size" />
+
+                    <LinearLayout
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_gravity="center_horizontal"
+                        android:layout_marginTop="10dp"
+                        android:layout_marginBottom="50dp"
+                        android:gravity="center"
+                        android:orientation="horizontal">
+
+                        <org.smartregister.view.customcontrols.CustomFontTextView
+                            android:id="@+id/address1"
+                            style="@style/CustomFontTextViewStyle.ClientList.Light"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:gravity="center_horizontal"
+                            android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                            android:textColor="@color/white" />
+
+                        <LinearLayout
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:orientation="horizontal">
+
+                            <org.smartregister.view.customcontrols.CustomFontTextView
+                                android:id="@+id/hhid"
+                                style="@style/CustomFontTextViewStyle.ClientList.Light"
+                                android:layout_width="wrap_content"
+                                android:layout_height="wrap_content"
+                                android:gravity="center_horizontal"
+                                android:text="Choma"
+                                android:paddingStart="0dp"
+                                android:textAppearance="@style/TextAppearance.AppCompat.Small"
+                                android:textColor="@color/white" />
+
+                        </LinearLayout>
+
+                    </LinearLayout>
+
+
+                </LinearLayout>
+
+            </com.google.android.material.appbar.CollapsingToolbarLayout>
+
+
+        </com.google.android.material.appbar.AppBarLayout>
+
+        <RelativeLayout
+            android:layout_below="@+id/collapsing_toolbar_appbarlayout"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/referralRecyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+
+            <LinearLayout
+                android:id="@+id/child_container"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:orientation="vertical"
+                android:visibility="visible">
+
+                <ImageView
+                    android:layout_width="50dp"
+                    android:layout_height="50dp"
+                    android:layout_gravity="center_horizontal"
+                    android:src="@drawable/no_referral" />
+
+                <TextView
+                    android:id="@+id/txtNoReferral"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:gravity="center_horizontal"
+                    android:text="No referrals have been added"
+                    android:textSize="20dp" />
+
+            </LinearLayout>
+
+
+
+        </RelativeLayout>
+
+
+    </RelativeLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
-Change the label on the registers from Index VCA register to VCA register. Because when we say Index VCA registers, users expect to see a list of the index only and not other members
- Change the icon for refreshing the page on the landing page. Add a button and label it “Refresh” to differentiate with the icon used for synchronization on the side navigation menu.
- On follow up visit if the VCA is above the age 5 then we should not show questions under the section “Under-Five Children (ALL)”
-  Allow the user to fill in the “Date referred” on the referral form, currently this information is already prefilled on the referral feature found on the VCA profile
 -When a user clicks on the child safety plan and saves, the page should redirect to “Add Actions” instead of the safety plan. The implementation should be the same as that of a case plan.
 -On monitoring plans on the child safety plans, make sure we are capturing information on when these actions will be confirmed, frequency and by who.
 -Change the label “Type of Caregiver Service (s)” to “Type of VCA Service (s)” on the VCA service report found on the VCA profile
 -Allow the user to be able to fill in “Days missed as reported by OVC/Caregiver”, currently this is not clickable on household visitation
 -Case worker phone number should be picked on the profile for the family member on History.
 -“Province” should be prefilled on VCA screening for the family member.
 -“Nearest landmark “ should be prefilled on VCA screening for the family member, remember this information has been captured already
 -Make sure the user can view the referrals once submitted for the caregiver and edit. Follow the implementation method used on the VCA profile to display referrals.
- Remove the fields “Name of case worker conducting assessment ”, “Date case worker signs ” and “verified by case manager ” on household visitation for caregiver.
 -Make sure when the service has been provided to the caregiver and household, the caseworker can view this information. This was working properly but now it has stopped.
- The service “Child or Caregiver referred to health, legal or other services” should be shown on the caregiver and VCA only and not on Household services.
 -On the WE form once information has been captured on the initial - this is question 1 to 4 on the subsequent visit, the user does not need to re-enter this information because it has been captured already.